### PR TITLE
CHORE(update): update to the latest versions

### DIFF
--- a/config.js
+++ b/config.js
@@ -17,63 +17,86 @@ System.config({
 System.config({
   "map": {
     "Intl.js": "github:andyearnshaw/Intl.js@0.1.4",
-    "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.1",
-    "aurelia-event-aggregator": "github:aurelia/event-aggregator@0.8.0",
-    "aurelia-loader-default": "github:aurelia/loader-default@0.10.0",
-    "aurelia-templating": "github:aurelia/templating@0.15.3",
+    "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.11.0",
+    "aurelia-event-aggregator": "github:aurelia/event-aggregator@0.9.0",
+    "aurelia-loader-default": "github:aurelia/loader-default@0.11.0",
+    "aurelia-templating": "github:aurelia/templating@0.16.0",
     "babel": "npm:babel-core@5.8.23",
     "babel-runtime": "npm:babel-runtime@5.8.20",
     "core-js": "npm:core-js@0.9.18",
     "i18next": "github:i18next/i18next@1.10.2",
     "text": "github:systemjs/plugin-text@0.0.2",
-    "github:aurelia/binding@0.9.1": {
-      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.1",
-      "aurelia-metadata": "github:aurelia/metadata@0.8.0",
-      "aurelia-task-queue": "github:aurelia/task-queue@0.7.0",
+    "github:aurelia/binding@0.10.0": {
+      "aurelia-metadata": "github:aurelia/metadata@0.9.0",
+      "aurelia-pal": "github:aurelia/pal@0.2.0",
+      "aurelia-task-queue": "github:aurelia/task-queue@0.8.0",
       "core-js": "npm:core-js@0.9.18"
     },
-    "github:aurelia/dependency-injection@0.10.1": {
-      "aurelia-logging": "github:aurelia/logging@0.7.0",
-      "aurelia-metadata": "github:aurelia/metadata@0.8.0",
+    "github:aurelia/dependency-injection@0.11.0": {
+      "aurelia-logging": "github:aurelia/logging@0.8.0",
+      "aurelia-metadata": "github:aurelia/metadata@0.9.0",
+      "aurelia-pal": "github:aurelia/pal@0.2.0",
       "core-js": "npm:core-js@0.9.18"
     },
-    "github:aurelia/event-aggregator@0.8.0": {
-      "aurelia-logging": "github:aurelia/logging@0.7.0"
+    "github:aurelia/event-aggregator@0.9.0": {
+      "aurelia-logging": "github:aurelia/logging@0.8.0"
     },
-    "github:aurelia/loader-default@0.10.0": {
-      "aurelia-loader": "github:aurelia/loader@0.9.0",
-      "aurelia-metadata": "github:aurelia/metadata@0.8.0"
+    "github:aurelia/loader-default@0.11.0": {
+      "aurelia-loader": "github:aurelia/loader@0.10.0",
+      "aurelia-metadata": "github:aurelia/metadata@0.9.0",
+      "aurelia-pal": "github:aurelia/pal@0.2.0"
     },
-    "github:aurelia/loader@0.9.0": {
-      "aurelia-html-template-element": "github:aurelia/html-template-element@0.3.0",
-      "aurelia-metadata": "github:aurelia/metadata@0.8.0",
-      "aurelia-path": "github:aurelia/path@0.9.0",
-      "core-js": "github:zloirock/core-js@0.8.4"
+    "github:aurelia/loader@0.10.0": {
+      "aurelia-metadata": "github:aurelia/metadata@0.9.0",
+      "aurelia-path": "github:aurelia/path@0.10.0"
     },
-    "github:aurelia/metadata@0.8.0": {
+    "github:aurelia/metadata@0.9.0": {
+      "aurelia-pal": "github:aurelia/pal@0.2.0",
       "core-js": "npm:core-js@0.9.18"
     },
-    "github:aurelia/templating@0.15.3": {
-      "aurelia-binding": "github:aurelia/binding@0.9.1",
-      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.1",
-      "aurelia-html-template-element": "github:aurelia/html-template-element@0.3.0",
-      "aurelia-loader": "github:aurelia/loader@0.9.0",
-      "aurelia-logging": "github:aurelia/logging@0.7.0",
-      "aurelia-metadata": "github:aurelia/metadata@0.8.0",
-      "aurelia-path": "github:aurelia/path@0.9.0",
-      "aurelia-task-queue": "github:aurelia/task-queue@0.7.0",
+    "github:aurelia/task-queue@0.8.0": {
+      "aurelia-pal": "github:aurelia/pal@0.2.0"
+    },
+    "github:aurelia/templating@0.16.0": {
+      "aurelia-binding": "github:aurelia/binding@0.10.0",
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.11.0",
+      "aurelia-loader": "github:aurelia/loader@0.10.0",
+      "aurelia-logging": "github:aurelia/logging@0.8.0",
+      "aurelia-metadata": "github:aurelia/metadata@0.9.0",
+      "aurelia-pal": "github:aurelia/pal@0.2.0",
+      "aurelia-path": "github:aurelia/path@0.10.0",
+      "aurelia-task-queue": "github:aurelia/task-queue@0.8.0",
       "core-js": "npm:core-js@0.9.18"
     },
-    "github:jspm/nodelibs-process@0.1.1": {
-      "process": "npm:process@0.10.1"
+    "github:jspm/nodelibs-assert@0.1.0": {
+      "assert": "npm:assert@1.3.0"
+    },
+    "github:jspm/nodelibs-process@0.1.2": {
+      "process": "npm:process@0.11.2"
+    },
+    "github:jspm/nodelibs-util@0.1.0": {
+      "util": "npm:util@0.10.3"
+    },
+    "npm:assert@1.3.0": {
+      "util": "npm:util@0.10.3"
     },
     "npm:babel-runtime@5.8.20": {
-      "process": "github:jspm/nodelibs-process@0.1.1"
+      "process": "github:jspm/nodelibs-process@0.1.2"
     },
     "npm:core-js@0.9.18": {
       "fs": "github:jspm/nodelibs-fs@0.1.2",
-      "process": "github:jspm/nodelibs-process@0.1.1",
+      "process": "github:jspm/nodelibs-process@0.1.2",
       "systemjs-json": "github:systemjs/plugin-json@0.1.0"
+    },
+    "npm:inherits@2.0.1": {
+      "util": "github:jspm/nodelibs-util@0.1.0"
+    },
+    "npm:process@0.11.2": {
+      "assert": "github:jspm/nodelibs-assert@0.1.0"
+    },
+    "npm:util@0.10.3": {
+      "inherits": "npm:inherits@2.0.1",
+      "process": "github:jspm/nodelibs-process@0.1.2"
     }
   }
 });

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     },
     "dependencies": {
       "Intl.js": "github:andyearnshaw/Intl.js@^0.1.4",
-      "aurelia-dependency-injection": "github:aurelia/dependency-injection@^0.10.1",
-      "aurelia-event-aggregator": "github:aurelia/event-aggregator@^0.8.0",
-      "aurelia-loader-default": "github:aurelia/loader-default@^0.10.0",
-      "aurelia-templating": "github:aurelia/templating@^0.15.3",
+      "aurelia-dependency-injection": "github:aurelia/dependency-injection@^0.11.0",
+      "aurelia-event-aggregator": "github:aurelia/event-aggregator@^0.9.0",
+      "aurelia-loader-default": "github:aurelia/loader-default@^0.11.0",
+      "aurelia-templating": "github:aurelia/templating@^0.16.0",
       "i18next": "github:i18next/i18next@^1.9.0"
     },
     "devDependencies": {

--- a/test/unit/i18n-attribute.spec.js
+++ b/test/unit/i18n-attribute.spec.js
@@ -1,6 +1,6 @@
 import {TCustomAttribute, TParamsCustomAttribute} from '../../src/t';
 import {Container} from 'aurelia-dependency-injection';
-import {BehaviorInstance} from 'aurelia-templating';
+import {templatingEngine} from 'aurelia-templating';
 import {I18N} from '../../src/i18n';
 
 describe('testing i18n attributes', () => {
@@ -13,7 +13,7 @@ describe('testing i18n attributes', () => {
 
 
   it('should raise value change on i18n custom attribute', done => {
-    let i18nAttribute = BehaviorInstance.createForUnitTest(TCustomAttribute);
+    let i18nAttribute = templatingEngine.createModelForUnitTest(TCustomAttribute);
     spyOn(i18nAttribute, 'valueChanged');
 
     // disable DOM operations by mocking the specific function
@@ -28,10 +28,10 @@ describe('testing i18n attributes', () => {
   });
 
   it('should listen to params changes', done => {
-    let paramsAttribute = BehaviorInstance.createForUnitTest(TParamsCustomAttribute);
+    let paramsAttribute = templatingEngine.createModelForUnitTest(TParamsCustomAttribute);
     container.registerInstance(TParamsCustomAttribute, paramsAttribute);
 
-    let i18nAttribute = BehaviorInstance.createForUnitTest(TCustomAttribute);
+    let i18nAttribute = templatingEngine.createModelForUnitTest(TCustomAttribute);
     spyOn(i18nAttribute, 'paramsChanged').and.callThrough();
 
     paramsAttribute.value = 'foo';


### PR DESCRIPTION
Getting two errors when running the tests though:

```
Chrome 45.0.2454 (Windows 10 0.0.0) testing i18n attributes should raise value change on i18n custom attribute FAILED
        TypeError: Cannot read property 'analyze' of undefined
            at Object.createModelForUnitTest (D:/Development/i18n/jspm_packages/github/aurelia/templating@0.16.0/aurelia-templating.js:3901:48)
            at Object.<anonymous> (D:/Development/i18n/test/unit/i18n-attribute.spec.js:27:48)
```

this is after changing `BehaviorInstance.createForUnitTest` to `templatingEngine.createModelForUnitTest`. I have tried to fix this by initializing aurelia-pal, but this didn't have any effect.