### PR TITLE
fix - event aggregator breaking change fix of Aurelia Mid-October 2015

### DIFF
--- a/src/t.js
+++ b/src/t.js
@@ -72,6 +72,6 @@ export class TCustomAttribute {
   }
 
   unbind() {
-    this.subscription();
+    this.subscription.dispose();
   }
 }


### PR DESCRIPTION
Added fix for event aggregator breaking change for the dispose.

> The EventAggregator now returns a subscription object from its subscribe method. The subscription has a dispose method to unsubscribe from the original event.
http://blog.durandal.io/2015/10/13/aurelia-mid-october-2015-releases-performance-and-portable-javascript/