### PR TITLE
fix(event-aggregator): dispose ea subscriptions correctly

### DIFF
--- a/src/base-i18n.js
+++ b/src/base-i18n.js
@@ -19,6 +19,6 @@ export class BaseI18N {
   }
 
   detached() {
-    this.__i18nDisposer();
+    this.__i18nDisposer.dispose();
   }
 }

--- a/src/t.js
+++ b/src/t.js
@@ -72,6 +72,6 @@ export class TCustomAttribute {
   }
 
   unbind() {
-    this.subscription();
+    this.subscription.dispose();
   }
 }

--- a/test/unit/i18n.spec.js
+++ b/test/unit/i18n.spec.js
@@ -114,7 +114,7 @@ describe('testing i18n translations', () => {
 
   it('should trigger an event when switching locales', (done) => {
     var subscription = sut.ea.subscribe('i18n:locale:changed', (payload) => {
-      subscription();
+      subscription.dispose();
 
       expect(payload.oldValue).toBe('en');
       expect(payload.newValue).toBe('de');


### PR DESCRIPTION
Sorry, missed the breaking changes to the ea subscription in the PR I made yesterday. Didn't get any errors when I tested since I don't use attributes in my app.

this fixes this error:
```
ERROR [app-router] TypeError: this.subscription is not a function
at TCustomAttribute.unbind (http://10.222.201.57:8081/jspm_packages/github/aurelia/i18n@0.2.5/t.js:118:14)
at Controller.unbind (http://10.222.201.57:8081/jspm_packages/github/aurelia/templating@0.16.0/aurelia-templating.js:2724:20)
at View.unbind (http://10.222.201.57:8081/jspm_packages/github/aurelia/templating@0.16.0/aurelia-templating.js:841:26)
at ViewFactory.returnViewToCache (http://10.222.201.57:8081/jspm_packages/github/aurelia/templating@0.16.0/aurelia-templating.js:1731:14)
at View.returnToCache (http://10.222.201.57:8081/jspm_packages/github/aurelia/templating@0.16.0/aurelia-templating.js:753:24)
at removeAction (http://10.222.201.57:8081/jspm_packages/github/aurelia/templating@0.16.0/aurelia-templating.js:1246:25)
at ViewSlot.removeAll (http://10.222.201.57:8081/jspm_packages/github/aurelia/templating@0.16.0/aurelia-templating.js:1259:7)
at RouterView.swap (http://10.222.201.57:8081/jspm_packages/github/aurelia/templating-router@0.17.0/router-view.js:57:42)
at http://10.222.201.57:8081/jspm_packages/github/aurelia/router@0.13.0/aurelia-router.js:926:29
at Array.forEach (native)
```