### PR TITLE
fix(i18n): marked optional arguments

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -22,7 +22,7 @@ export class I18N {
     }
   }
 
-  setup(options) {
+  setup(options?) {
     const defaultOptions = {
       resGetPath: 'locale/__lng__/__ns__.json',
       lng: 'en',
@@ -56,15 +56,15 @@ export class I18N {
     return this.i18next.lng();
   }
 
-  nf(options, locales) {
+  nf(options?, locales?) {
     return new this.Intl.NumberFormat(locales || this.getLocale(), options || {});
   }
 
-  df(options, locales) {
+  df(options?, locales?) {
     return new this.Intl.DateTimeFormat(locales || this.getLocale(), options);
   }
 
-  tr(key, options) {
+  tr(key, options?) {
     let fullOptions = this.globalVars;
 
     if (options !== undefined) {


### PR DESCRIPTION
Using this plugin in a TypeScript project, missing optional arguments such as `options` in `tr(key, options)` throw compiler errors since they are not marked as optional with a question mark. This PR fixes this, marking optional arguments as optional.