### PR TITLE
translation of attributes containing dash not working

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -135,7 +135,7 @@ export class I18N {
 
     for (let key of keys) {
       // remove the optional attribute
-      let re = /\[([a-z]*)\]/g;
+      let re = /\[([a-z\-]*)\]/g;
 
       let m;
       let attr = 'text';

--- a/test/unit/i18n-attribute.spec.js
+++ b/test/unit/i18n-attribute.spec.js
@@ -63,4 +63,19 @@ describe('testing i18n attributes', () => {
       });
     });
   });
+
+  it('should raise value change on i18n custom attribute with dash in name', done => {
+    let i18nAttribute = templatingEngine.createViewModelForUnitTest(TCustomAttribute);
+    spyOn(i18nAttribute, 'valueChanged');
+
+    // disable DOM operations by mocking the specific function
+    spyOn(container.get(I18N), 'updateValue');
+
+    i18nAttribute.value = 'foo-bar';
+
+    setTimeout(() => {
+      expect(i18nAttribute.valueChanged).toHaveBeenCalledWith('foo-bar', undefined);
+      done();
+    });
+  });
 });


### PR DESCRIPTION
the `text` attribute is set instead

Example which is not working without this patch:
```
<paper-input t="[label]profile:nameLabel;[error-message]profile:nameErrorMessage" value.two-way="name"></paper-input>
```