### PR TITLE
Wait i18next before load

### DIFF
--- a/dist/amd/aurelia-i18n.d.ts
+++ b/dist/amd/aurelia-i18n.d.ts
@@ -29,6 +29,7 @@ declare module 'aurelia-i18n' {
   /*eslint no-cond-assign: 0*/
   export class I18N {
     globalVars: any;
+    i18nextDefered: any;
     constructor(ea: any, signaler: any);
     setup(options?: any): any;
     setLocale(locale: any): any;

--- a/dist/amd/aurelia-i18n.d.ts
+++ b/dist/amd/aurelia-i18n.d.ts
@@ -32,6 +32,7 @@ declare module 'aurelia-i18n' {
     i18nextDefered: any;
     constructor(ea: any, signaler: any);
     setup(options?: any): any;
+    i18nextReady(): any;
     setLocale(locale: any): any;
     getLocale(): any;
     nf(options?: any, locales?: any): any;
@@ -70,7 +71,8 @@ declare module 'aurelia-i18n' {
   }
   export class RelativeTime {
     static inject(): any;
-    constructor(i18n: any);
+    constructor(i18n: any, ea: any);
+    setup(locales: any): any;
     getRelativeTime(time: any): any;
     getTimeDiffDescription(diff: any, unit: any, timeDivisor: any): any;
   }

--- a/dist/amd/i18n.js
+++ b/dist/amd/i18n.js
@@ -22,18 +22,27 @@ define(['exports', 'i18next'], function (exports, _i18next) {
 
   var I18N = exports.I18N = function () {
     function I18N(ea, signaler) {
+      var _this = this;
+
       _classCallCheck(this, I18N);
 
       this.globalVars = {};
+      this.i18nextDefered = {
+        resolve: null,
+        promise: null
+      };
 
       this.i18next = _i18next2.default;
       this.ea = ea;
       this.Intl = window.Intl;
       this.signaler = signaler;
+      this.i18nextDefered.promise = new Promise(function (resolve) {
+        return _this.i18nextDefered.resolve = resolve;
+      });
     }
 
     I18N.prototype.setup = function setup(options) {
-      var _this = this;
+      var _this2 = this;
 
       var defaultOptions = {
         compatibilityAPI: 'v1',
@@ -44,25 +53,25 @@ define(['exports', 'i18next'], function (exports, _i18next) {
         debug: false
       };
 
-      return new Promise(function (resolve) {
-        _i18next2.default.init(options || defaultOptions, function (err, t) {
-          if (_i18next2.default.options.attributes instanceof String) {
-            _i18next2.default.options.attributes = [_i18next2.default.options.attributes];
-          }
+      _i18next2.default.init(options || defaultOptions, function (err, t) {
+        if (_i18next2.default.options.attributes instanceof String) {
+          _i18next2.default.options.attributes = [_i18next2.default.options.attributes];
+        }
 
-          resolve(_this.i18next);
-        });
+        _this2.i18nextDefered.resolve(_this2.i18next);
       });
+
+      return this.i18nextDefered.promise;
     };
 
     I18N.prototype.setLocale = function setLocale(locale) {
-      var _this2 = this;
+      var _this3 = this;
 
       return new Promise(function (resolve) {
-        var oldLocale = _this2.getLocale();
-        _this2.i18next.changeLanguage(locale, function (err, tr) {
-          _this2.ea.publish('i18n:locale:changed', { oldValue: oldLocale, newValue: locale });
-          _this2.signaler.signal('aurelia-translation-signal');
+        var oldLocale = _this3.getLocale();
+        _this3.i18next.changeLanguage(locale, function (err, tr) {
+          _this3.ea.publish('i18n:locale:changed', { oldValue: oldLocale, newValue: locale });
+          _this3.signaler.signal('aurelia-translation-signal');
           resolve(tr);
         });
       });
@@ -136,6 +145,14 @@ define(['exports', 'i18next'], function (exports, _i18next) {
     };
 
     I18N.prototype.updateValue = function updateValue(node, value, params) {
+      var _this4 = this;
+
+      this.i18nextDefered.promise.then(function () {
+        return _this4._updateValue(node, value, params);
+      });
+    };
+
+    I18N.prototype._updateValue = function _updateValue(node, value, params) {
       if (value === null || value === undefined) {
         return;
       }

--- a/dist/amd/i18n.js
+++ b/dist/amd/i18n.js
@@ -64,6 +64,10 @@ define(['exports', 'i18next'], function (exports, _i18next) {
       return this.i18nextDefered.promise;
     };
 
+    I18N.prototype.i18nextReady = function i18nextReady() {
+      return this.i18nextDefered.promise;
+    };
+
     I18N.prototype.setLocale = function setLocale(locale) {
       var _this3 = this;
 

--- a/dist/aurelia-i18n.d.ts
+++ b/dist/aurelia-i18n.d.ts
@@ -29,6 +29,7 @@ declare module 'aurelia-i18n' {
   /*eslint no-cond-assign: 0*/
   export class I18N {
     globalVars: any;
+    i18nextDefered: any;
     constructor(ea: any, signaler: any);
     setup(options?: any): any;
     setLocale(locale: any): any;

--- a/dist/aurelia-i18n.d.ts
+++ b/dist/aurelia-i18n.d.ts
@@ -32,6 +32,7 @@ declare module 'aurelia-i18n' {
     i18nextDefered: any;
     constructor(ea: any, signaler: any);
     setup(options?: any): any;
+    i18nextReady(): any;
     setLocale(locale: any): any;
     getLocale(): any;
     nf(options?: any, locales?: any): any;
@@ -70,7 +71,8 @@ declare module 'aurelia-i18n' {
   }
   export class RelativeTime {
     static inject(): any;
-    constructor(i18n: any);
+    constructor(i18n: any, ea: any);
+    setup(locales: any): any;
     getRelativeTime(time: any): any;
     getTimeDiffDescription(diff: any, unit: any, timeDivisor: any): any;
   }

--- a/dist/aurelia-i18n.js
+++ b/dist/aurelia-i18n.js
@@ -293,12 +293,17 @@ export class LazyOptional {
 export class I18N {
 
   globalVars = {};
+  i18nextDefered = {
+    resolve: null,
+    promise: null
+  };
 
   constructor(ea, signaler) {
     this.i18next = i18next;
     this.ea = ea;
     this.Intl = window.Intl;
     this.signaler = signaler;
+    this.i18nextDefered.promise = new Promise((resolve) => this.i18nextDefered.resolve = resolve);
   }
 
   setup(options?) {
@@ -311,16 +316,16 @@ export class I18N {
       debug: false
     };
 
-    return new Promise((resolve) => {
-      i18next.init(options || defaultOptions, (err, t) => {
-        //make sure attributes is an array in case a string was provided
-        if (i18next.options.attributes instanceof String) {
-          i18next.options.attributes = [i18next.options.attributes];
-        }
+    i18next.init(options || defaultOptions, (err, t) => {
+      //make sure attributes is an array in case a string was provided
+      if (i18next.options.attributes instanceof String) {
+        i18next.options.attributes = [i18next.options.attributes];
+      }
 
-        resolve(this.i18next);
-      });
+      this.i18nextDefered.resolve(this.i18next);
     });
+
+    return this.i18nextDefered.promise;
   }
 
   setLocale(locale) {
@@ -419,6 +424,10 @@ export class I18N {
   }
 
   updateValue(node, value, params) {
+    this.i18nextDefered.promise.then(() => this._updateValue(node, value, params));
+  }
+
+  _updateValue(node, value, params) {
     if (value === null || value === undefined) {
       return;
     }

--- a/dist/aurelia-i18n.js
+++ b/dist/aurelia-i18n.js
@@ -328,6 +328,10 @@ export class I18N {
     return this.i18nextDefered.promise;
   }
 
+  i18nextReady() {
+    return this.i18nextDefered.promise;
+  }
+
   setLocale(locale) {
     return new Promise( resolve => {
       let oldLocale = this.getLocale();
@@ -531,24 +535,32 @@ export class NfValueConverter {
 }
 
 export class RelativeTime {
-  static inject() { return [I18N]; }
-  constructor(i18n) {
+  static inject() { return [I18N, EventAggregator]; }
+  constructor(i18n, ea) {
     this.service = i18n;
+    this.ea = ea;
 
-    let trans = translations.default || translations;
-
-    Object.keys(trans).map( (key) => {
-      let translation = trans[key].translation;
-      let options = i18n.i18next.options;
-
-      if (options.interpolation && options.interpolation.prefix !== '__' || options.interpolation.suffix !== '__') {
-        for (let subkey in translation) {
-          translation[subkey] = translation[subkey].replace('__count__', options.interpolation.prefix + 'count' + options.interpolation.suffix);
-        }
-      }
-
-      this.service.i18next.addResources(key, 'translation', translation);
+    this.service.i18nextReady().then(() => {
+       this.setup();
     });
+    this.ea.subscribe('i18n:locale:changed', locales => {
+      this.setup(locales);
+    });
+  }
+
+  setup(locales) {
+    let trans = translations.default || translations;
+    let key = locales && locales.newValue ? locales.newValue : this.service.getLocale();
+    let translation = trans[key].translation;
+    let options = this.service.i18next.options;
+
+    if (options.interpolation && options.interpolation.prefix !== '__' || options.interpolation.suffix !== '__') {
+      for (let subkey in translation) {
+        translation[subkey] = translation[subkey].replace('__count__', options.interpolation.prefix + 'count' + options.interpolation.suffix);
+      }
+    }
+
+    this.service.i18next.addResources(key, 'translation', translation);
   }
 
   getRelativeTime(time) {

--- a/dist/commonjs/aurelia-i18n.d.ts
+++ b/dist/commonjs/aurelia-i18n.d.ts
@@ -29,6 +29,7 @@ declare module 'aurelia-i18n' {
   /*eslint no-cond-assign: 0*/
   export class I18N {
     globalVars: any;
+    i18nextDefered: any;
     constructor(ea: any, signaler: any);
     setup(options?: any): any;
     setLocale(locale: any): any;

--- a/dist/commonjs/aurelia-i18n.d.ts
+++ b/dist/commonjs/aurelia-i18n.d.ts
@@ -32,6 +32,7 @@ declare module 'aurelia-i18n' {
     i18nextDefered: any;
     constructor(ea: any, signaler: any);
     setup(options?: any): any;
+    i18nextReady(): any;
     setLocale(locale: any): any;
     getLocale(): any;
     nf(options?: any, locales?: any): any;
@@ -70,7 +71,8 @@ declare module 'aurelia-i18n' {
   }
   export class RelativeTime {
     static inject(): any;
-    constructor(i18n: any);
+    constructor(i18n: any, ea: any);
+    setup(locales: any): any;
     getRelativeTime(time: any): any;
     getTimeDiffDescription(diff: any, unit: any, timeDivisor: any): any;
   }

--- a/dist/commonjs/i18n.js
+++ b/dist/commonjs/i18n.js
@@ -57,6 +57,10 @@ var I18N = exports.I18N = function () {
     return this.i18nextDefered.promise;
   };
 
+  I18N.prototype.i18nextReady = function i18nextReady() {
+    return this.i18nextDefered.promise;
+  };
+
   I18N.prototype.setLocale = function setLocale(locale) {
     var _this3 = this;
 

--- a/dist/commonjs/relativeTime.js
+++ b/dist/commonjs/relativeTime.js
@@ -9,35 +9,45 @@ var _i18n = require('./i18n');
 
 var _relative = require('./defaultTranslations/relative.time');
 
+var _aureliaEventAggregator = require('aurelia-event-aggregator');
+
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
 var RelativeTime = exports.RelativeTime = function () {
   RelativeTime.inject = function inject() {
-    return [_i18n.I18N];
+    return [_i18n.I18N, _aureliaEventAggregator.EventAggregator];
   };
 
-  function RelativeTime(i18n) {
+  function RelativeTime(i18n, ea) {
     var _this = this;
 
     _classCallCheck(this, RelativeTime);
 
     this.service = i18n;
+    this.ea = ea;
 
-    var trans = _relative.translations.default || _relative.translations;
-
-    Object.keys(trans).map(function (key) {
-      var translation = trans[key].translation;
-      var options = i18n.i18next.options;
-
-      if (options.interpolation && options.interpolation.prefix !== '__' || options.interpolation.suffix !== '__') {
-        for (var subkey in translation) {
-          translation[subkey] = translation[subkey].replace('__count__', options.interpolation.prefix + 'count' + options.interpolation.suffix);
-        }
-      }
-
-      _this.service.i18next.addResources(key, 'translation', translation);
+    this.service.i18nextReady().then(function () {
+      _this.setup();
+    });
+    this.ea.subscribe('i18n:locale:changed', function (locales) {
+      _this.setup(locales);
     });
   }
+
+  RelativeTime.prototype.setup = function setup(locales) {
+    var trans = _relative.translations.default || _relative.translations;
+    var key = locales && locales.newValue ? locales.newValue : this.service.getLocale();
+    var translation = trans[key].translation;
+    var options = this.service.i18next.options;
+
+    if (options.interpolation && options.interpolation.prefix !== '__' || options.interpolation.suffix !== '__') {
+      for (var subkey in translation) {
+        translation[subkey] = translation[subkey].replace('__count__', options.interpolation.prefix + 'count' + options.interpolation.suffix);
+      }
+    }
+
+    this.service.i18next.addResources(key, 'translation', translation);
+  };
 
   RelativeTime.prototype.getRelativeTime = function getRelativeTime(time) {
     var now = new Date();

--- a/dist/es2015/aurelia-i18n.d.ts
+++ b/dist/es2015/aurelia-i18n.d.ts
@@ -29,6 +29,7 @@ declare module 'aurelia-i18n' {
   /*eslint no-cond-assign: 0*/
   export class I18N {
     globalVars: any;
+    i18nextDefered: any;
     constructor(ea: any, signaler: any);
     setup(options?: any): any;
     setLocale(locale: any): any;

--- a/dist/es2015/aurelia-i18n.d.ts
+++ b/dist/es2015/aurelia-i18n.d.ts
@@ -32,6 +32,7 @@ declare module 'aurelia-i18n' {
     i18nextDefered: any;
     constructor(ea: any, signaler: any);
     setup(options?: any): any;
+    i18nextReady(): any;
     setLocale(locale: any): any;
     getLocale(): any;
     nf(options?: any, locales?: any): any;
@@ -70,7 +71,8 @@ declare module 'aurelia-i18n' {
   }
   export class RelativeTime {
     static inject(): any;
-    constructor(i18n: any);
+    constructor(i18n: any, ea: any);
+    setup(locales: any): any;
     getRelativeTime(time: any): any;
     getTimeDiffDescription(diff: any, unit: any, timeDivisor: any): any;
   }

--- a/dist/es2015/i18n.js
+++ b/dist/es2015/i18n.js
@@ -5,11 +5,16 @@ export let I18N = class I18N {
 
   constructor(ea, signaler) {
     this.globalVars = {};
+    this.i18nextDefered = {
+      resolve: null,
+      promise: null
+    };
 
     this.i18next = i18next;
     this.ea = ea;
     this.Intl = window.Intl;
     this.signaler = signaler;
+    this.i18nextDefered.promise = new Promise(resolve => this.i18nextDefered.resolve = resolve);
   }
 
   setup(options) {
@@ -22,15 +27,15 @@ export let I18N = class I18N {
       debug: false
     };
 
-    return new Promise(resolve => {
-      i18next.init(options || defaultOptions, (err, t) => {
-        if (i18next.options.attributes instanceof String) {
-          i18next.options.attributes = [i18next.options.attributes];
-        }
+    i18next.init(options || defaultOptions, (err, t) => {
+      if (i18next.options.attributes instanceof String) {
+        i18next.options.attributes = [i18next.options.attributes];
+      }
 
-        resolve(this.i18next);
-      });
+      this.i18nextDefered.resolve(this.i18next);
     });
+
+    return this.i18nextDefered.promise;
   }
 
   setLocale(locale) {
@@ -111,6 +116,10 @@ export let I18N = class I18N {
   }
 
   updateValue(node, value, params) {
+    this.i18nextDefered.promise.then(() => this._updateValue(node, value, params));
+  }
+
+  _updateValue(node, value, params) {
     if (value === null || value === undefined) {
       return;
     }

--- a/dist/es2015/i18n.js
+++ b/dist/es2015/i18n.js
@@ -38,6 +38,10 @@ export let I18N = class I18N {
     return this.i18nextDefered.promise;
   }
 
+  i18nextReady() {
+    return this.i18nextDefered.promise;
+  }
+
   setLocale(locale) {
     return new Promise(resolve => {
       let oldLocale = this.getLocale();

--- a/dist/es2015/relativeTime.js
+++ b/dist/es2015/relativeTime.js
@@ -1,27 +1,36 @@
 import { I18N } from './i18n';
 import { translations } from './defaultTranslations/relative.time';
+import { EventAggregator } from 'aurelia-event-aggregator';
 
 export let RelativeTime = class RelativeTime {
   static inject() {
-    return [I18N];
+    return [I18N, EventAggregator];
   }
-  constructor(i18n) {
+  constructor(i18n, ea) {
     this.service = i18n;
+    this.ea = ea;
 
-    let trans = translations.default || translations;
-
-    Object.keys(trans).map(key => {
-      let translation = trans[key].translation;
-      let options = i18n.i18next.options;
-
-      if (options.interpolation && options.interpolation.prefix !== '__' || options.interpolation.suffix !== '__') {
-        for (let subkey in translation) {
-          translation[subkey] = translation[subkey].replace('__count__', options.interpolation.prefix + 'count' + options.interpolation.suffix);
-        }
-      }
-
-      this.service.i18next.addResources(key, 'translation', translation);
+    this.service.i18nextReady().then(() => {
+      this.setup();
     });
+    this.ea.subscribe('i18n:locale:changed', locales => {
+      this.setup(locales);
+    });
+  }
+
+  setup(locales) {
+    let trans = translations.default || translations;
+    let key = locales && locales.newValue ? locales.newValue : this.service.getLocale();
+    let translation = trans[key].translation;
+    let options = this.service.i18next.options;
+
+    if (options.interpolation && options.interpolation.prefix !== '__' || options.interpolation.suffix !== '__') {
+      for (let subkey in translation) {
+        translation[subkey] = translation[subkey].replace('__count__', options.interpolation.prefix + 'count' + options.interpolation.suffix);
+      }
+    }
+
+    this.service.i18next.addResources(key, 'translation', translation);
   }
 
   getRelativeTime(time) {

--- a/dist/system/aurelia-i18n.d.ts
+++ b/dist/system/aurelia-i18n.d.ts
@@ -29,6 +29,7 @@ declare module 'aurelia-i18n' {
   /*eslint no-cond-assign: 0*/
   export class I18N {
     globalVars: any;
+    i18nextDefered: any;
     constructor(ea: any, signaler: any);
     setup(options?: any): any;
     setLocale(locale: any): any;

--- a/dist/system/aurelia-i18n.d.ts
+++ b/dist/system/aurelia-i18n.d.ts
@@ -32,6 +32,7 @@ declare module 'aurelia-i18n' {
     i18nextDefered: any;
     constructor(ea: any, signaler: any);
     setup(options?: any): any;
+    i18nextReady(): any;
     setLocale(locale: any): any;
     getLocale(): any;
     nf(options?: any, locales?: any): any;
@@ -70,7 +71,8 @@ declare module 'aurelia-i18n' {
   }
   export class RelativeTime {
     static inject(): any;
-    constructor(i18n: any);
+    constructor(i18n: any, ea: any);
+    setup(locales: any): any;
     getRelativeTime(time: any): any;
     getTimeDiffDescription(diff: any, unit: any, timeDivisor: any): any;
   }

--- a/dist/system/i18n.js
+++ b/dist/system/i18n.js
@@ -58,6 +58,10 @@ System.register(['i18next'], function (_export, _context) {
           return this.i18nextDefered.promise;
         };
 
+        I18N.prototype.i18nextReady = function i18nextReady() {
+          return this.i18nextDefered.promise;
+        };
+
         I18N.prototype.setLocale = function setLocale(locale) {
           var _this3 = this;
 

--- a/dist/system/i18n.js
+++ b/dist/system/i18n.js
@@ -16,18 +16,27 @@ System.register(['i18next'], function (_export, _context) {
     execute: function () {
       _export('I18N', I18N = function () {
         function I18N(ea, signaler) {
+          var _this = this;
+
           _classCallCheck(this, I18N);
 
           this.globalVars = {};
+          this.i18nextDefered = {
+            resolve: null,
+            promise: null
+          };
 
           this.i18next = i18next;
           this.ea = ea;
           this.Intl = window.Intl;
           this.signaler = signaler;
+          this.i18nextDefered.promise = new Promise(function (resolve) {
+            return _this.i18nextDefered.resolve = resolve;
+          });
         }
 
         I18N.prototype.setup = function setup(options) {
-          var _this = this;
+          var _this2 = this;
 
           var defaultOptions = {
             compatibilityAPI: 'v1',
@@ -38,25 +47,25 @@ System.register(['i18next'], function (_export, _context) {
             debug: false
           };
 
-          return new Promise(function (resolve) {
-            i18next.init(options || defaultOptions, function (err, t) {
-              if (i18next.options.attributes instanceof String) {
-                i18next.options.attributes = [i18next.options.attributes];
-              }
+          i18next.init(options || defaultOptions, function (err, t) {
+            if (i18next.options.attributes instanceof String) {
+              i18next.options.attributes = [i18next.options.attributes];
+            }
 
-              resolve(_this.i18next);
-            });
+            _this2.i18nextDefered.resolve(_this2.i18next);
           });
+
+          return this.i18nextDefered.promise;
         };
 
         I18N.prototype.setLocale = function setLocale(locale) {
-          var _this2 = this;
+          var _this3 = this;
 
           return new Promise(function (resolve) {
-            var oldLocale = _this2.getLocale();
-            _this2.i18next.changeLanguage(locale, function (err, tr) {
-              _this2.ea.publish('i18n:locale:changed', { oldValue: oldLocale, newValue: locale });
-              _this2.signaler.signal('aurelia-translation-signal');
+            var oldLocale = _this3.getLocale();
+            _this3.i18next.changeLanguage(locale, function (err, tr) {
+              _this3.ea.publish('i18n:locale:changed', { oldValue: oldLocale, newValue: locale });
+              _this3.signaler.signal('aurelia-translation-signal');
               resolve(tr);
             });
           });
@@ -130,6 +139,14 @@ System.register(['i18next'], function (_export, _context) {
         };
 
         I18N.prototype.updateValue = function updateValue(node, value, params) {
+          var _this4 = this;
+
+          this.i18nextDefered.promise.then(function () {
+            return _this4._updateValue(node, value, params);
+          });
+        };
+
+        I18N.prototype._updateValue = function _updateValue(node, value, params) {
           if (value === null || value === undefined) {
             return;
           }

--- a/dist/temp/aurelia-i18n.js
+++ b/dist/temp/aurelia-i18n.js
@@ -359,6 +359,10 @@ var I18N = exports.I18N = function () {
     return this.i18nextDefered.promise;
   };
 
+  I18N.prototype.i18nextReady = function i18nextReady() {
+    return this.i18nextDefered.promise;
+  };
+
   I18N.prototype.setLocale = function setLocale(locale) {
     var _this4 = this;
 
@@ -568,31 +572,39 @@ var NfValueConverter = exports.NfValueConverter = function () {
 
 var RelativeTime = exports.RelativeTime = function () {
   RelativeTime.inject = function inject() {
-    return [I18N];
+    return [I18N, _aureliaEventAggregator.EventAggregator];
   };
 
-  function RelativeTime(i18n) {
+  function RelativeTime(i18n, ea) {
     var _this7 = this;
 
     _classCallCheck(this, RelativeTime);
 
     this.service = i18n;
+    this.ea = ea;
 
-    var trans = translations.default || translations;
-
-    Object.keys(trans).map(function (key) {
-      var translation = trans[key].translation;
-      var options = i18n.i18next.options;
-
-      if (options.interpolation && options.interpolation.prefix !== '__' || options.interpolation.suffix !== '__') {
-        for (var subkey in translation) {
-          translation[subkey] = translation[subkey].replace('__count__', options.interpolation.prefix + 'count' + options.interpolation.suffix);
-        }
-      }
-
-      _this7.service.i18next.addResources(key, 'translation', translation);
+    this.service.i18nextReady().then(function () {
+      _this7.setup();
+    });
+    this.ea.subscribe('i18n:locale:changed', function (locales) {
+      _this7.setup(locales);
     });
   }
+
+  RelativeTime.prototype.setup = function setup(locales) {
+    var trans = translations.default || translations;
+    var key = locales && locales.newValue ? locales.newValue : this.service.getLocale();
+    var translation = trans[key].translation;
+    var options = this.service.i18next.options;
+
+    if (options.interpolation && options.interpolation.prefix !== '__' || options.interpolation.suffix !== '__') {
+      for (var subkey in translation) {
+        translation[subkey] = translation[subkey].replace('__count__', options.interpolation.prefix + 'count' + options.interpolation.suffix);
+      }
+    }
+
+    this.service.i18next.addResources(key, 'translation', translation);
+  };
 
   RelativeTime.prototype.getRelativeTime = function getRelativeTime(time) {
     var now = new Date();

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -39,6 +39,10 @@ export class I18N {
     return this.i18nextDefered.promise;
   }
 
+  i18nextReady() {
+    return this.i18nextDefered.promise;
+  }
+
   setLocale(locale) {
     return new Promise( resolve => {
       let oldLocale = this.getLocale();

--- a/test/unit/i18n.update-translations.spec.js
+++ b/test/unit/i18n.update-translations.spec.js
@@ -40,7 +40,7 @@ describe('testing i18n translation update', () => {
 
     ea  = new EventAggregator();
     sut = new I18N(ea, new BindingSignaler());
-    sut.setup({
+    let i18nextSetupPromise = sut.setup({
       resources: resources,
       lng: 'en',
       attributes: ['t', 'data-i18n'],
@@ -49,18 +49,19 @@ describe('testing i18n translation update', () => {
     });
 
     //load the the html fixture
-    System.import('fixture:template.html!text').then((result) => {
+    let systemImportPromise = System.import('fixture:template.html!text').then((result) => {
       template           = document.createElement('div');
       template.innerHTML = result;
       if (template.firstChild instanceof HTMLTemplateElement) template.innerHTML = template.firstChild.innerHTML;
       document.body.appendChild(template);
-      done();
     });
 
     //update the translations in the template when the locale changes
     ea.subscribe('i18n:locale:changed', payload => {
       sut.updateTranslations(template);
     });
+
+    Promise.all([i18nextSetupPromise, systemImportPromise]).then(() => done());
   });
 
 
@@ -92,85 +93,109 @@ describe('testing i18n translation update', () => {
     expect(template.querySelector('#test2').innerHTML.trim()).toBe('Description');
   });
 
-  it('should translate contents of elements with a translation attribute', () => {
+  it('should translate contents of elements with a translation attribute', done => {
     expect(template.querySelector('#test1').innerHTML.trim()).toBe('Title');
     expect(template.querySelector('#test2').innerHTML.trim()).toBe('Description');
-    sut.setLocale('de');
-    expect(template.querySelector('#test1').innerHTML.trim()).toBe('Titel');
-    expect(template.querySelector('#test2').innerHTML.trim()).toBe('Beschreibung');
+    sut.setLocale('de').then(() => {
+      expect(template.querySelector('#test1').innerHTML.trim()).toBe('Titel');
+      expect(template.querySelector('#test2').innerHTML.trim()).toBe('Beschreibung');
+      done();
+    });
   });
 
-  it('should translate nested keys', () => {
+  it('should translate nested keys', done => {
     expect(template.querySelector('#test-nested').innerHTML.trim()).toBe('Description Title');
-    sut.setLocale('de');
-    expect(template.querySelector('#test-nested').innerHTML.trim()).toBe('Der Titel ist der Kopf');
+    sut.setLocale('de').then(() => {
+      expect(template.querySelector('#test-nested').innerHTML.trim()).toBe('Der Titel ist der Kopf');
+      done();
+    });
   });
 
-  it('should work with all attributes specified in the options', () => {
+  it('should work with all attributes specified in the options', done => {
     let el = template.querySelector('#test-other-attr');
     expect(el.innerHTML.trim()).toBe('Description');
-    sut.setLocale('de');
-    expect(el.innerHTML.trim()).toBe('Beschreibung');
+    sut.setLocale('de').then(() => {
+      expect(el.innerHTML.trim()).toBe('Beschreibung');
+      done();
+    });
   });
 
-  it('should set the textContent when using the [text] attribute', () => {
+  it('should set the textContent when using the [text] attribute', done => {
     let el = template.querySelector('#test-text');
     expect(el.innerHTML.trim()).toBe('Description');
-    sut.setLocale('de');
-    expect(el.innerHTML.trim()).toBe('Beschreibung');
+    sut.setLocale('de').then(() => {
+      expect(el.innerHTML.trim()).toBe('Beschreibung');
+      done();
+    });
   });
 
-  it('should escape html tags by default or when using [text]', () => {
+  it('should escape html tags by default or when using [text]', done => {
     let el = template.querySelector('#test-text-with-tags');
     expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>');
-    sut.setLocale('de');
-    expect(el.innerHTML.trim()).toBe('Beschreibung &lt;b&gt;mit Fettdruck&lt;/b&gt;');
+    sut.setLocale('de').then(() => {
+      expect(el.innerHTML.trim()).toBe('Beschreibung &lt;b&gt;mit Fettdruck&lt;/b&gt;');
+      done();
+    });
   });
 
-  it('should allow tags when using the [html] attribute', () => {
+  it('should allow tags when using the [html] attribute', done => {
     let el = template.querySelector('#test-html');
     expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>');
-    sut.setLocale('de');
-    expect(el.innerHTML.trim()).toBe('Beschreibung <b>mit Fettdruck</b>');
+    sut.setLocale('de').then(() => {
+      expect(el.innerHTML.trim()).toBe('Beschreibung <b>mit Fettdruck</b>');
+      done();
+    });
   });
 
-  it('should prepend the translation when using the [prepend] attribute, and it allows html', () => {
+  it('should prepend the translation when using the [prepend] attribute, and it allows html', done => {
     let el = template.querySelector('#test-prepend');
     expect(el.innerHTML.trim()).toBe('content');
-    sut.setLocale('de');
-    expect(el.innerHTML.trim()).toBe('Beschreibung <b>mit Fettdruck</b>content');
-    sut.setLocale('en');
-    expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>content');
-  });
+    sut.setLocale('de').then(() => {
+      expect(el.innerHTML.trim()).toBe('Beschreibung <b>mit Fettdruck</b>content');
+      return sut.setLocale('en');
+    }).then(() => {
+      expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>content');
+      done();
+    });
+    });
 
-  it('should append the translation when using the [append] attribute, and it allows html', () => {
+  it('should append the translation when using the [append] attribute, and it allows html', done => {
     let el = template.querySelector('#test-append');
     expect(el.innerHTML.trim()).toBe('content');
-    sut.setLocale('de');
-    expect(el.innerHTML.trim()).toBe('contentBeschreibung <b>mit Fettdruck</b>');
-    sut.setLocale('en');
-    expect(el.innerHTML.trim()).toBe('contentDescription <b>with some bold</b>');
+    sut.setLocale('de').then(() => {
+      expect(el.innerHTML.trim()).toBe('contentBeschreibung <b>mit Fettdruck</b>');
+      return sut.setLocale('en');
+    }).then(() => {
+      expect(el.innerHTML.trim()).toBe('contentDescription <b>with some bold</b>');
+      done();
+    });
   });
 
-  it('should set multiple keys when separated with a semicolon', () => {
+  it('should set multiple keys when separated with a semicolon', done => {
     let el = template.querySelector('#test-multiple');
     expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>');
     expect(el.className).toBe('');
-    sut.setLocale('de');
-    expect(el.innerHTML.trim()).toBe('Beschreibung <b>mit Fettdruck</b>');
-    expect(el.className).toBe('blue');
-    sut.setLocale('en');
-    expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>');
-    expect(el.className).toBe('red');
+    sut.setLocale('de').then(() => {
+      expect(el.innerHTML.trim()).toBe('Beschreibung <b>mit Fettdruck</b>');
+      expect(el.className).toBe('blue');
+      return sut.setLocale('en');
+    }).then(() => {
+      expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>');
+      expect(el.className).toBe('red');
+      done();
+    });
   });
 
-  it('should set the src attribute for images', () => {
+  it('should set the src attribute for images', done => {
     let el = template.querySelector('#test-img');
     expect(el.getAttribute('src')).toBeNull();
-    sut.setLocale('de');
-    expect(el.getAttribute('src')).toBe('testimage-german.jpg');
-    sut.setLocale('en');
-    expect(el.getAttribute('src')).toBe('testimage-english.jpg');
+    sut.setLocale('de').then(() => {
+      expect(el.getAttribute('src')).toBe('testimage-german.jpg');
+      return sut.setLocale('en');
+    }).then(() => {
+      expect(el.getAttribute('src')).toBe('testimage-english.jpg');
+      done();
+    });
   });
 
 });

--- a/test/unit/relative.time.spec.js
+++ b/test/unit/relative.time.spec.js
@@ -6,16 +6,17 @@ import {EventAggregator} from 'aurelia-event-aggregator';
 describe('testing relative time support', () => {
   let sut;
   let i18n;
+  let ea;
 
-  beforeEach( () => {
-    i18n = new I18N(new EventAggregator(), new BindingSignaler());
+  beforeEach( done => {
+    ea = new EventAggregator();
+    i18n = new I18N(ea, new BindingSignaler());
+    sut = new RelativeTime(i18n, ea);
     i18n.setup({
       lng: 'en',
       fallbackLng: 'en',
       debug: false
-    });
-
-    sut = new RelativeTime(i18n);
+    }).then(() => done());
   });
 
   it('should provide now unit', () => {
@@ -96,8 +97,10 @@ describe('testing relative time support', () => {
     });
   });
 
-  it('should respect interpolation settings', () => {
-    let customInterpolationSettings = new I18N(new EventAggregator(), new BindingSignaler());
+  it('should respect interpolation settings', done => {
+    let ea = new EventAggregator();
+    let customInterpolationSettings = new I18N(ea, new BindingSignaler());
+    let customSut = new RelativeTime(customInterpolationSettings, ea);
     customInterpolationSettings.setup({
       lng: 'en',
       getAsync: false,
@@ -106,13 +109,13 @@ describe('testing relative time support', () => {
       debug: false,
       interpolationPrefix: '${',
       interpolationSuffix: '}'
+    }).then(() => {
+      let expectedDate = new Date();
+      expectedDate.setHours(new Date().getHours() - 1);
+
+      expect(customSut.getRelativeTime(expectedDate)).toBe('1 hour ago');
+
+      done();
     });
-
-    let customSut = new RelativeTime(customInterpolationSettings);
-
-    let expectedDate = new Date();
-    expectedDate.setHours(new Date().getHours() - 1);
-
-    expect(customSut.getRelativeTime(expectedDate)).toBe('1 hour ago');
   });
 });


### PR DESCRIPTION
A timeout of 10ms was introduced in [version 2.4.0 of i18next](https://github.com/i18next/i18next/blob/master/CHANGELOG.md#240). This caused two issues:
- aurelia-i18n starts to update the values before the translations are loaded. This is fixed by the first commit.
- aurelia-i18n adds translations for relative time before the translations of the users are loaded. In this situation, the XHR backend considers that the translations are already loaded and won't fetch the one defined by the users. This is fixed by the second commit.