### PR TITLE
Add support for culture names

### DIFF
--- a/src/relativeTime.js
+++ b/src/relativeTime.js
@@ -19,6 +19,8 @@ export class RelativeTime {
   setup(locales) {
     let trans = translations.default || translations;
     let key = locales && locales.newValue ? locales.newValue : this.service.getLocale();
+    let index = key.indexOf("-");
+    if (index >= 0 && !trans[key]) key = key.substring(0, index);
     let translation = trans[key].translation;
     let options = this.service.i18next.options;
 

--- a/src/relativeTime.js
+++ b/src/relativeTime.js
@@ -22,20 +22,19 @@ export class RelativeTime {
     let fallbackLng = this.service.fallbackLng;    
     let index = 0;
     
-    let translation = (trans[key] || trans[fallbackLng] || {}).translation;
-    let useFallback = true;
-    
     if ((index = key.indexOf("-")) >= 0) {
         let baseLocale = key.substring(0, index);
         
-        if (trans[baseLocale]) { 
-            useFallback = false; //There is a base locale, do not use fallback for main locale if it doesn't exist
+        if (trans[baseLocale]) {             
             this.addTranslationResource(baseLocale, trans[baseLocale].translation);
         }
     }
     
-    if (useFallback || trans[key]) {
-        this.addTranslationResource(key, translation);
+    if (trans[key]) {
+        this.addTranslationResource(key, trans[key].translation);
+    }
+    if (trans[fallbackLng]) {
+        this.addTranslationResource(key, trans[fallbackLng].translation);
     }
   }
   

--- a/src/relativeTime.js
+++ b/src/relativeTime.js
@@ -16,16 +16,30 @@ export class RelativeTime {
     });
   }
 
-  setup(locales) {
+  setup(locales) {      
     let trans = translations.default || translations;
     let key = locales && locales.newValue ? locales.newValue : this.service.getLocale();
     let fallbackLng = this.service.fallbackLng;    
     let index = 0;
-    let originalKey = key;
     
-    if (!trans[key] && (index = key.indexOf("-")) >= 0) key = key.substring(0, index);
     let translation = (trans[key] || trans[fallbackLng] || {}).translation;
+    let useFallback = true;
     
+    if ((index = key.indexOf("-")) >= 0) {
+        let baseLocale = key.substring(0, index);
+        
+        if (trans[baseLocale]) { 
+            useFallback = false; //There is a base locale, do not use fallback for main locale if it doesn't exist
+            this.addTranslationResource(baseLocale, trans[baseLocale].translation);
+        }
+    }
+    
+    if (useFallback || trans[key]) {
+        this.addTranslationResource(key, translation);
+    }
+  }
+  
+  addTranslationResource(key, translation) {    
     let options = this.service.i18next.options;
 
     if (options.interpolation && options.interpolation.prefix !== '__' || options.interpolation.suffix !== '__') {
@@ -34,7 +48,7 @@ export class RelativeTime {
       }
     }
     
-    this.service.i18next.addResources(originalKey, 'translation', translation);
+    this.service.i18next.addResources(key, 'translation', translation);
   }
 
   getRelativeTime(time) {

--- a/src/relativeTime.js
+++ b/src/relativeTime.js
@@ -20,9 +20,12 @@ export class RelativeTime {
     let trans = translations.default || translations;
     let key = locales && locales.newValue ? locales.newValue : this.service.getLocale();
     let fallbackLng = this.service.fallbackLng;    
-    let index = key.indexOf("-");
-    if (index >= 0 && !trans[key]) key = key.substring(0, index);
+    let index = 0;
+    let originalKey = key;
+    
+    if (!trans[key] && (index = key.indexOf("-")) >= 0) key = key.substring(0, index);
     let translation = (trans[key] || trans[fallbackLng] || {}).translation;
+    
     let options = this.service.i18next.options;
 
     if (options.interpolation && options.interpolation.prefix !== '__' || options.interpolation.suffix !== '__') {
@@ -30,8 +33,8 @@ export class RelativeTime {
         translation[subkey] = translation[subkey].replace('__count__', options.interpolation.prefix + 'count' + options.interpolation.suffix);
       }
     }
-
-    this.service.i18next.addResources(key, 'translation', translation);
+    
+    this.service.i18next.addResources(originalKey, 'translation', translation);
   }
 
   getRelativeTime(time) {

--- a/test/unit/relative.time.spec.js
+++ b/test/unit/relative.time.spec.js
@@ -109,7 +109,7 @@ describe('testing relative time support', () => {
   });
 
   it('should try to find the language of the locale when the full locale is not found', (done) => {
-      expect(translations['nl-BE']).toBe(undefined);
+      expect(translations['nl-BE']).toBe(undefined); //If this fails, someone added translations for nl-BE  
       i18n.setLocale('nl-BE').then( () => {
         let expectedDate = new Date();
         expectedDate.setHours(new Date().getHours() + 2);
@@ -119,14 +119,24 @@ describe('testing relative time support', () => {
       });
   });
   
-  it('should provide the translation for the full locale when available', (done) => {
-      expect(translations['nl-XX']).toBe(undefined);
+  it('should provide the translation for the full locale when available', (done) => {      
       translations['nl-XX'] = { translation: {    'hour_in_plural': 'in __count__ periods of an hourly length', 'hour_in': 'in __count__ uur'} };
       i18n.setLocale('nl-XX').then( () => {
         let expectedDate = new Date();
         expectedDate.setHours(new Date().getHours() + 2);
 
         expect(sut.getRelativeTime(expectedDate)).toBe('in 2 periods of an hourly length');
+        done();
+      });
+  });
+  
+  it('should provide the translation for the base locale when a key is not found in the full locale', (done) => {      
+      translations['nl-XX'] = { translation: {    'hour_in_plural': 'in __count__ periods of an hourly length', 'hour_in': 'in __count__ uur'} };
+      i18n.setLocale('nl-XX').then( () => {
+        let expectedDate = new Date();
+        expectedDate.setMinutes(new Date().getMinutes() + 2);
+
+        expect(sut.getRelativeTime(expectedDate)).toBe('in 2 minuten');
         done();
       });
   });

--- a/test/unit/relative.time.spec.js
+++ b/test/unit/relative.time.spec.js
@@ -2,6 +2,7 @@ import {I18N} from '../../src/i18n';
 import {RelativeTime} from '../../src/relativeTime';
 import {BindingSignaler} from 'aurelia-templating-resources';
 import {EventAggregator} from 'aurelia-event-aggregator';
+import {translations} from  '../../src/defaultTranslations/relative.time';
 
 describe('testing relative time support', () => {
   let sut;
@@ -107,6 +108,29 @@ describe('testing relative time support', () => {
     });
   });
 
+  it('should try to find the language of the locale when the full locale is not found', (done) => {
+      expect(translations['nl-BE']).toBe(undefined);
+      i18n.setLocale('nl-BE').then( () => {
+        let expectedDate = new Date();
+        expectedDate.setHours(new Date().getHours() + 2);
+
+        expect(sut.getRelativeTime(expectedDate)).toBe('in 2 uren');
+        done();
+      });
+  });
+  
+  it('should provide the translation for the full locale when available', (done) => {
+      expect(translations['nl-XX']).toBe(undefined);
+      translations['nl-XX'] = { translation: {    'hour_in_plural': 'in __count__ periods of an hourly length', 'hour_in': 'in __count__ uur'} };
+      i18n.setLocale('nl-XX').then( () => {
+        let expectedDate = new Date();
+        expectedDate.setHours(new Date().getHours() + 2);
+
+        expect(sut.getRelativeTime(expectedDate)).toBe('in 2 periods of an hourly length');
+        done();
+      });
+  });
+  
   it('should respect interpolation settings', done => {
     let ea = new EventAggregator();
     let customInterpolationSettings = new I18N(ea, new BindingSignaler());


### PR DESCRIPTION
i18n.language returns "nl-NL" on my machine, which is not defined in translations. There should probably also be better exception handling here to make clear that the language/culture is not supported.