### PR TITLE
complete typings for i18next and i18next-xhr-backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,79 +52,110 @@ Under the hood it uses the [i18next](http://i18next.com/) library.
 
 1. In your project install the plugin via `jspm` with following command
 
-  ```shell
-jspm install aurelia-i18n
-  ```
+    ```shell
+    jspm install aurelia-i18n
+    ```
 2. Make sure you use [manual bootstrapping](http://aurelia.io/docs#startup-and-configuration). In order to do so open your `index.html` and locate the element with the attribute aurelia-app. Change it to look like this:
 
-  ```html
-  <body aurelia-app="main">
-  ...
-  ```
+    ```html
+    <body aurelia-app="main">
+    ...
+    ```
 3. Create folder `locale` in your projects root
 4. For each locale create a new folder with it's name (e.g. `en`, `de`, ...)
 5. In those subfolders create a file named `translation.json` which contains your language specific translations. Below you can find a sample `en-EN` translation file. The full potential of i18next is achieved through a specific translation-file schema. Consult the [i18next docs](http://i18next.com/docs/) to find out more about it.
 
-  ```javascript
-  {
-    "score": "Score: {{score}}",
-    "lives": "{{count}} life remaining",
-    "lives_plural": "{{count}} lives remaining",
-    "lives_indefinite": "a life remaining",
-    "lives_plural_indefinite": "some lives remaining",
-    "friend": "A friend",
-    "friend_male": "A boyfriend",
-    "friend_female": "A girlfriend"
-  }
-  ```
+    ```javascript
+    {
+        "score": "Score: {{score}}",
+        "lives": "{{count}} life remaining",
+        "lives_plural": "{{count}} lives remaining",
+        "lives_indefinite": "a life remaining",
+        "lives_plural_indefinite": "some lives remaining",
+        "friend": "A friend",
+        "friend_male": "A boyfriend",
+        "friend_female": "A girlfriend"
+    }
+    ```
 6. NEW!: Install a backend plugin
 From v.2 you have to pick your own backend service. For this guide we're going to leverage the [XHR Plugin](https://github.com/i18next/i18next-xhr-backend)
 Install it in the root of your project via `jspm install npm:i18next-xhr-backend`.
-
-
 7. Create (if you haven't already) a file `main.js` in your `src` folder with following content:
 
-```javascript
-  import {I18N} from 'aurelia-i18n';
-  import Backend from 'i18next-xhr-backend'; // <-- your previously installed backend plugin 
-
-  export function configure(aurelia) {
-    aurelia.use
-      .standardConfiguration()
-      .developmentLogging()
-      .plugin('aurelia-i18n', (instance) => {
-        // register backend plugin
-        instance.i18next.use(Backend);
+    ```javascript
+    import {I18N} from 'aurelia-i18n';
+    import Backend from 'i18next-xhr-backend'; // <-- your previously installed backend plugin 
+    
+    export function configure(aurelia) {
+        aurelia.use
+          .standardConfiguration()
+          .developmentLogging()
+          .plugin('aurelia-i18n', (instance) => {
+            // register backend plugin
+            instance.i18next.use(Backend);
+            
+            // adapt options to your needs (see http://i18next.com/docs/options/)
+            // make sure to return the promise of the setup method, in order to guarantee proper loading
+            return instance.setup({
+              backend: {                                  // <-- configure backend settings
+                loadPath: '/locales/{{lng}}/{{ns}}.json', // <-- XHR settings for where to get the files from
+              },
+              lng : 'de',
+              attributes : ['t','i18n'],
+              fallbackLng : 'en',
+              debug : false
+            });
+          });
         
-        // adapt options to your needs (see http://i18next.com/docs/options/)
-        // make sure to return the promise of the setup method, in order to guarantee proper loading
-        return instance.setup({
-          backend: {                                  // <-- configure backend settings
-            loadPath: '/locales/{{lng}}/{{ns}}.json', // <-- XHR settings for where to get the files from
-          },
-          lng : 'de',
-          attributes : ['t','i18n'],
-          fallbackLng : 'en',
-          debug : false
-        });
-      });
+        aurelia.start().then(a => a.setRoot());
+    }
+    ```
 
-    aurelia.start().then(a => a.setRoot());
-  }
-```
+    > You may also group your translations by namespaces, spread across multiple files. Say you have the standard translation.json
+    and an additional `nav.json` for the navigation items, you can configure aurelia-i18n by passing the `ns` setting in the config object
+    containing the different namespaces as well as the default namespace.
 
-> You may also group your translations by namespaces, spread across multiple files. Say you have the standard translation.json
-and an additional `nav.json` for the navigation items, you can configure aurelia-i18n by passing the `ns` setting in the config object
-containing the different namespaces as well as the default namespace.
-```
-instance.setup({
-  ...
-  ns: { 
-    namespaces: ['translation','nav'],
-    defaultNs: 'translation'
-  }
-});
-```
+    ```javascript
+    instance.setup({
+      ...
+      ns: { 
+        namespaces: ['translation','nav'],
+        defaultNs: 'translation'
+      }
+    });
+    ```
+
+8. If You use typescript
+
+    Unfortunately creators of [i18next](http://i18next.com/) and [i18next-xhr-backend](https://github.com/i18next/i18next-xhr-backend) have not provided typings for these libraries for now. So, during typescript compilation process You will see next error messages:
+    ``` javascript
+    "/yourHost/pathToApp/pathToFile/filename.ts(3,26): Cannot find module 'i18next-xhr-backend'."
+    "/yourHost/pathToApp/jspm_packages/npm/aurelia-i18n@0.5.2/aurelia-i18n.d.ts(2,23): Cannot find module 'i18next'."
+    ```
+
+    First of all You need to get `*.d.ts` files:
+    
+    1. **i18next**
+    
+        - If You use [typings](https://github.com/typings/typings) (it is most likely true) you can istall typings for [i18next](http://i18next.com/) with next command in console: 
+            ``` javascript
+            typings install i18next --ambient
+            ```
+        - on other hand You can use similar file from this repository (`doc/i18next.d.ts`)
+        
+    2. **i18next-xhr-backend**
+        - use typings file from this repository `doc/i18next-xhr-backend.d.ts`
+    > in order to comply with some neat project structure You would copy `*.d.ts` files from `doc/*.d.ts` to some other folder, e.g. `/customTypings`
+    
+    The next step - to give the compiler know about your  `*.d.ts` files. Add the following section to your `tsconfig.json` file.
+    ```javascript
+    //...some configuration code
+    "filesGlob": [
+        "./typings/browser.d.ts", //this must be specified in case if You use typings(https://github.com/typings/typings)
+        "./your_custom_typings_folder_path/**/*.d.ts", //if You use two typings file from this repositorie (`doc/*.d.ts`)
+      ],
+    //...some configuration code
+    ```
 
 ## How to use this plugin
 i18next translations work by setting up an active locale, which you've setup above in the init phase with the property `lng`.

--- a/doc/core-js.d.ts
+++ b/doc/core-js.d.ts
@@ -1,9 +1,4 @@
 declare module 'core-js' {
-        var coreJs;
-        export default coreJs;
-}
-
-declare module 'i18next' {
-  var i18next;
-  export default i18next;
+    var coreJs;
+    export default coreJs;
 }

--- a/doc/i18next-xhr-backend.d.ts
+++ b/doc/i18next-xhr-backend.d.ts
@@ -1,0 +1,27 @@
+declare module 'i18next-xhr-backend' {
+
+    interface Interpolator {
+        interpolate: () => string
+    }
+    interface Services {
+        interpolator: Interpolator
+    }
+    export class Backend {
+        type: 'backend';
+        services: Services;
+        options: {
+            loadPath: string,
+            addPath:  string,
+            allowMultiLoading: boolean,
+            parse: () => {},
+            crossDomain: boolean,
+            ajax: () => void
+        };
+        constructor(services: Services, options?: {});
+        init(services: Services, options?: {}): void;
+        readMulti(languages: Array, namespaces: Array, callback: () => void): void;
+        read(language: {}, namespace: {}, callback: () => void): void;
+        loadUrl(url: string, callback: () => void): void;
+        create(languages: any[], namespace: string, key: string, fallbackValue: string): void;
+    }
+}

--- a/doc/i18next.d.ts
+++ b/doc/i18next.d.ts
@@ -1,0 +1,125 @@
+// Type definitions for i18next v2.3.4
+// Project: http://i18next.com
+// Definitions by: Michael Ledin <https://github.com/mxl>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Sources: https://github.com/i18next/i18next/
+
+
+declare namespace I18next {
+    interface ResourceStore {
+        [language: string]: ResourceStoreLanguage;
+    }
+
+    interface ResourceStoreLanguage {
+        [namespace: string]: ResourceStoreKey;
+    }
+
+    interface ResourceStoreKey {
+        [key: string]: any;
+    }
+
+    interface InterpolationOptions {
+        escapeValue?: boolean;
+        prefix?: string;
+        suffix?: string;
+        prefixEscaped?: string;
+        suffixEscaped?: string;
+        unescapeSuffix?: string;
+        unescapePrefix?: string;
+        nestingPrefix?: string;
+        nestingSuffix?: string;
+        nestingPrefixEscaped?: string;
+        nestedSuffixEscaped?: string;
+        defaultVariables?: any;
+    }
+
+    interface TranslationOptions {
+        defaultValue?: string;
+        count?: number;
+        context?: any;
+        replace?: any;
+        lng?:string;
+        lngs?:string[];
+        fallbackLng?:string;
+        ns?:string|string[];
+        keySeparator?:string;
+        nsSeparator?:string;
+        returnObjects?:boolean;
+        joinArrays?:string;
+        postProcess?:string|any[];
+        interpolation?: InterpolationOptions;
+    }
+
+    interface Options {
+        debug?: boolean;
+        resources?: ResourceStore;
+        lng?: string;
+        fallbackLng?: string;
+        ns?: string|string[];
+        defaultNS?: string;
+        fallbackNS?: string|string[];
+        whitelist?:string[];
+        lowerCaseLng?: boolean;
+        load?: string
+        preload?: string[];
+        keySeparator?: string;
+        nsSeparator?: string;
+        pluralSeparator?: string;
+        contextSeparator?: string;
+        saveMissing?: boolean;
+        saveMissingTo?: string;
+        missingKeyHandler?: (lng:string, ns:string, key:string, fallbackValue:string) => void;
+        parseMissingKeyHandler?: (key:string) => void;
+        appendNamespaceToMissingKey?: boolean;
+        postProcess?: string|any[];
+        returnNull?: boolean;
+        returnEmptyString?: boolean;
+        returnObjects?: boolean;
+        returnedObjectHandler?: (key:string, value:string, options:any) => void;
+        joinArrays?: string;
+        overloadTranslationOptionHandler?: (args:any[]) => TranslationOptions;
+        interpolation?: InterpolationOptions;
+        detection?: any;
+        backend?: any;
+        cache?: any;
+    }
+
+    type TranslationFunction = (key:string, options?:TranslationOptions) => string;
+
+    class I18n {
+        constructor(options?:Options, callback?:(err:any, t:TranslationFunction) => void);
+
+        init(options?:Options, callback?:(err:any, t:TranslationFunction) => void):I18n;
+
+        loadResources(callback?:(err:any) => void):void;
+
+        use(module:any):I18n;
+
+        changeLanguage(lng:string, callback?:(err:any, t:TranslationFunction) => void):void;
+
+        getFixedT(lng?:string, ns?:string|string[]):TranslationFunction;
+
+        t(key:string, options?:TranslationOptions):string|any|Array<any>;
+
+        exists():boolean;
+
+        setDefaultNamespace(ns:string):void;
+
+        loadNamespaces(ns:string[], callback?:() => void):void;
+
+        loadLanguages(lngs:string[], callback?:()=>void):void;
+
+        dir(lng?:string):string;
+
+        createInstance(options?:Options, callback?:(err:any, t:TranslationFunction) => void):I18n;
+
+        cloneInstance(options?:Options, callback?:(err:any, t:TranslationFunction) => void):I18n;
+    }
+}
+
+declare module 'i18next' {
+    var i18next:I18next.I18n;
+
+    export default i18next;
+}

--- a/src/customTypings/i18next-xhr-backend.d.ts
+++ b/src/customTypings/i18next-xhr-backend.d.ts
@@ -1,0 +1,13 @@
+declare module 'i18next-xhr-backend' {
+    export class Backend {
+        type: any;
+        services: any;
+        options: any;
+        constructor(services: any, options?: {});
+        init(services: any, options?: {}): void;
+        readMulti(languages: any, namespaces: any, callback: any): void;
+        read(language: any, namespace: any, callback: any): void;
+        loadUrl(url: any, callback: any): void;
+        create(languages: any, namespace: any, key: any, fallbackValue: any): void;
+    }
+}

--- a/src/customTypings/i18next.d.ts
+++ b/src/customTypings/i18next.d.ts
@@ -1,0 +1,125 @@
+// Type definitions for i18next v2.3.4
+// Project: http://i18next.com
+// Definitions by: Michael Ledin <https://github.com/mxl>
+// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
+
+// Sources: https://github.com/i18next/i18next/
+
+
+declare namespace I18next {
+    interface ResourceStore {
+        [language: string]: ResourceStoreLanguage;
+    }
+
+    interface ResourceStoreLanguage {
+        [namespace: string]: ResourceStoreKey;
+    }
+
+    interface ResourceStoreKey {
+        [key: string]: any;
+    }
+
+    interface InterpolationOptions {
+        escapeValue?: boolean;
+        prefix?: string;
+        suffix?: string;
+        prefixEscaped?: string;
+        suffixEscaped?: string;
+        unescapeSuffix?: string;
+        unescapePrefix?: string;
+        nestingPrefix?: string;
+        nestingSuffix?: string;
+        nestingPrefixEscaped?: string;
+        nestedSuffixEscaped?: string;
+        defaultVariables?: any;
+    }
+
+    interface TranslationOptions {
+        defaultValue?: string;
+        count?: number;
+        context?: any;
+        replace?: any;
+        lng?:string;
+        lngs?:string[];
+        fallbackLng?:string;
+        ns?:string|string[];
+        keySeparator?:string;
+        nsSeparator?:string;
+        returnObjects?:boolean;
+        joinArrays?:string;
+        postProcess?:string|any[];
+        interpolation?: InterpolationOptions;
+    }
+
+    interface Options {
+        debug?: boolean;
+        resources?: ResourceStore;
+        lng?: string;
+        fallbackLng?: string;
+        ns?: string|string[];
+        defaultNS?: string;
+        fallbackNS?: string|string[];
+        whitelist?:string[];
+        lowerCaseLng?: boolean;
+        load?: string
+        preload?: string[];
+        keySeparator?: string;
+        nsSeparator?: string;
+        pluralSeparator?: string;
+        contextSeparator?: string;
+        saveMissing?: boolean;
+        saveMissingTo?: string;
+        missingKeyHandler?: (lng:string, ns:string, key:string, fallbackValue:string) => void;
+        parseMissingKeyHandler?: (key:string) => void;
+        appendNamespaceToMissingKey?: boolean;
+        postProcess?: string|any[];
+        returnNull?: boolean;
+        returnEmptyString?: boolean;
+        returnObjects?: boolean;
+        returnedObjectHandler?: (key:string, value:string, options:any) => void;
+        joinArrays?: string;
+        overloadTranslationOptionHandler?: (args:any[]) => TranslationOptions;
+        interpolation?: InterpolationOptions;
+        detection?: any;
+        backend?: any;
+        cache?: any;
+    }
+
+    type TranslationFunction = (key:string, options?:TranslationOptions) => string;
+
+    class I18n {
+        constructor(options?:Options, callback?:(err:any, t:TranslationFunction) => void);
+
+        init(options?:Options, callback?:(err:any, t:TranslationFunction) => void):I18n;
+
+        loadResources(callback?:(err:any) => void):void;
+
+        use(module:any):I18n;
+
+        changeLanguage(lng:string, callback?:(err:any, t:TranslationFunction) => void):void;
+
+        getFixedT(lng?:string, ns?:string|string[]):TranslationFunction;
+
+        t(key:string, options?:TranslationOptions):string|any|Array<any>;
+
+        exists():boolean;
+
+        setDefaultNamespace(ns:string):void;
+
+        loadNamespaces(ns:string[], callback?:() => void):void;
+
+        loadLanguages(lngs:string[], callback?:()=>void):void;
+
+        dir(lng?:string):string;
+
+        createInstance(options?:Options, callback?:(err:any, t:TranslationFunction) => void):I18n;
+
+        cloneInstance(options?:Options, callback?:(err:any, t:TranslationFunction) => void):I18n;
+    }
+}
+
+declare module 'i18next' {
+    var i18next:I18next.I18n;
+
+    export default i18next;
+}


### PR DESCRIPTION
if You try run example from documentation in typescript starterkit you will get next errors:
```
"/home/vagrant/app/src/main.ts(3,26): Cannot find module 'i18next-xhr-backend'."
"/home/vagrant/app/jspm_packages/npm/aurelia-i18n@0.5.2/aurelia-i18n.d.ts(2,23): Cannot find module 'i18next'."
```

I understand that perfect option is if authors of these libraries will provide their own implemented *.d.ts files. But could You consider adding 'temporary' d.ts files to sources of aurelia/i18n as a temporary fix? 