### PR TITLE
Add dependent modules to aurelia/build/resources in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,14 @@
     "yargs": "^4.7.1"
   },
   "aurelia": {
+    "build": {
+      "resources": [
+        "aurelia-i18n/t",
+        "aurelia-i18n/nf",
+        "aurelia-i18n/df",
+        "aurelia-i18n/rt"
+      ]
+    },
     "documentation": {
       "articles": []
     }


### PR DESCRIPTION
Added the list of dependent modules ("aurelia-i18n/t", "aurelia-i18n/nf", "aurelia-i18n/df", "aurelia-i18n/rt") to the property aurelia/build/resources in package.json.