### PR TITLE
update loadPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Install it in the root of your project via `jspm install npm:i18next-xhr-backend
             // make sure to return the promise of the setup method, in order to guarantee proper loading
             return instance.setup({
               backend: {                                  // <-- configure backend settings
-                loadPath: '/locales/{{lng}}/{{ns}}.json', // <-- XHR settings for where to get the files from
+                loadPath: './locales/{{lng}}/{{ns}}.json', // <-- XHR settings for where to get the files from
               },
               lng : 'de',
               attributes : ['t','i18n'],


### PR DESCRIPTION
The default loadPath in the configuration example doesn't work on Cordova as it looks in the root path rather than the web asset path.

This tiny change ensures it works on more platforms by default.