### PR TITLE
Make sure translations parameters are always applied

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -5,6 +5,7 @@ import {DOM} from 'aurelia-pal';
 export class I18N {
 
   globalVars = {};
+  params = {};
   i18nextDefered = {
     resolve: null,
     promise: null
@@ -140,7 +141,13 @@ export class I18N {
   }
 
   updateValue(node, value, params) {
-    this.i18nextDefered.promise.then(() => this._updateValue(node, value, params));
+    if (params) {
+      this.params[value] = params;
+    } else if (this.params[value]) {
+      params = this.params[value];
+    }
+
+    return this.i18nextDefered.promise.then(() => this._updateValue(node, value, params));
   }
 
   _updateValue(node, value, params) {

--- a/test/unit/fixtures/template.html
+++ b/test/unit/fixtures/template.html
@@ -9,6 +9,10 @@
     <p t="nested_referencing" id="test-nested">
       Description Title
     </p>-
+
+    <p t="params" t-params.bind="{name: 'Aurelia'}" id="test-params">
+        Params
+    </p>
         
     <p data-i18n="description" id="test-other-attr">
       Wrong Description

--- a/test/unit/fixtures/template.html
+++ b/test/unit/fixtures/template.html
@@ -1,9 +1,9 @@
 <template>
   
-    <h1 t="title" id="test1">Title</h1>
+    <h1 t="title" id="test1">WrongTitle</h1>
             
     <p t="description" id="test2">
-      Description
+      Wrong Description
     </p>
 
     <p t="nested_referencing" id="test-nested">
@@ -11,19 +11,19 @@
     </p>-
         
     <p data-i18n="description" id="test-other-attr">
-      Description
+      Wrong Description
     </p>
   
     <p t="[text]description" id="test-text">
-      Description
+      Wrong Description
     </p>
   
     <p t="description2" id="test-text-with-tags">
-      Description <b>with some bold</b>
+      Wrong Description <b>with some bold</b>
     </p>
   
     <p t="[html]description2" id="test-html">
-      Description <b>with some bold</b>
+      Wrong Description <b>with some bold</b>
     </p>
   
     <p t="[prepend]description2" id="test-prepend">content</p>
@@ -31,9 +31,9 @@
     <p t="[append]description2" id="test-append">content</p>
   
     <p t="[html]description2;[class]description-class" id="test-multiple">
-      Description <b>with some bold</b>
+      Wrong Description <b>with some bold</b>
     </p>
     
-    <img data-src="testimage-english.jpg" t="testimage" id="test-img"/>
+    <img data-src="wrong-testimage-english.jpg" t="testimage" id="test-img"/>
   
 </template>

--- a/test/unit/i18n.update-translations.spec.js
+++ b/test/unit/i18n.update-translations.spec.js
@@ -8,7 +8,7 @@ describe('testing i18n translation update', () => {
   let template;
   let ea;
 
-  beforeEach((done) => {
+  beforeEach(done => {
     System.config({
       'paths': {
         'fixture:*': 'test/unit/fixtures/*.js'
@@ -65,98 +65,106 @@ describe('testing i18n translation update', () => {
   });
 
 
-  it('should not update translations if no attributes defined in options', (done) => {
-    ea  = new EventAggregator();
-    sut = new I18N(ea, new BindingSignaler());
-    sut.setup({
-      resStore: resources,
-      lng: 'en',
-      getAsync: false,
-      sendMissing: false,
-      fallbackLng: 'en',
-      debug: false
+  describe('init locale', () => {
+    beforeEach(done => {
+      sut.setLocale('en').then(() => done());
     });
 
-    //load the the html fixture
-    System.import('fixture:template.html!text').then((result) => {
-      template           = document.createElement('div');
-      template.innerHTML = result;
-      if (template.firstChild instanceof HTMLTemplateElement) template.innerHTML = template.firstChild.innerHTML;
-      document.body.appendChild(template);
-      done();
+
+    it('should not update translations if no attributes defined in options', (done) => {
+      ea = new EventAggregator();
+      sut = new I18N(ea, new BindingSignaler());
+      sut.setup({
+        resStore: resources,
+        lng: 'en',
+        getAsync: false,
+        sendMissing: false,
+        fallbackLng: 'en',
+        debug: false
+      });
+
+      //load the the html fixture
+      System.import('fixture:template.html!text').then((result) => {
+        template = document.createElement('div');
+        template.innerHTML = result;
+        if (template.firstChild instanceof HTMLTemplateElement)
+          template.innerHTML = template.firstChild.innerHTML;
+        document.body.appendChild(template);
+        done();
+      });
+
+      expect(template.querySelector('#test1').innerHTML.trim()).toBe('Title');
+      expect(template.querySelector('#test2').innerHTML.trim()).toBe('Description');
+      sut.setLocale('de');
+      expect(template.querySelector('#test1').innerHTML.trim()).toBe('Title');
+      expect(template.querySelector('#test2').innerHTML.trim()).toBe('Description');
     });
 
-    expect(template.querySelector('#test1').innerHTML.trim()).toBe('Title');
-    expect(template.querySelector('#test2').innerHTML.trim()).toBe('Description');
-    sut.setLocale('de');
-    expect(template.querySelector('#test1').innerHTML.trim()).toBe('Title');
-    expect(template.querySelector('#test2').innerHTML.trim()).toBe('Description');
-  });
-
-  it('should translate contents of elements with a translation attribute', done => {
-    expect(template.querySelector('#test1').innerHTML.trim()).toBe('Title');
-    expect(template.querySelector('#test2').innerHTML.trim()).toBe('Description');
-    sut.setLocale('de').then(() => {
-      expect(template.querySelector('#test1').innerHTML.trim()).toBe('Titel');
-      expect(template.querySelector('#test2').innerHTML.trim()).toBe('Beschreibung');
-      done();
+    it('should translate contents of elements with a translation attribute', done => {
+      expect(template.querySelector('#test1').innerHTML.trim()).toBe('Title');
+      expect(template.querySelector('#test2').innerHTML.trim()).toBe('Description');
+      sut.setLocale('de').then(() => {
+        expect(template.querySelector('#test1').innerHTML.trim()).toBe('Titel');
+        expect(template.querySelector('#test2').innerHTML.trim()).toBe('Beschreibung');
+        done();
+      });
     });
-  });
 
-  it('should translate nested keys', done => {
-    expect(template.querySelector('#test-nested').innerHTML.trim()).toBe('Description Title');
-    sut.setLocale('de').then(() => {
-      expect(template.querySelector('#test-nested').innerHTML.trim()).toBe('Der Titel ist der Kopf');
-      done();
+    it('should translate nested keys', done => {
+      expect(template.querySelector('#test-nested').innerHTML.trim()).toBe('The Title is the header');
+      sut.setLocale('de').then(() => {
+        expect(template.querySelector('#test-nested').innerHTML.trim()).toBe('Der Titel ist der Kopf');
+        done();
+      });
     });
-  });
 
-  it('should work with all attributes specified in the options', done => {
-    let el = template.querySelector('#test-other-attr');
-    expect(el.innerHTML.trim()).toBe('Description');
-    sut.setLocale('de').then(() => {
-      expect(el.innerHTML.trim()).toBe('Beschreibung');
-      done();
+    it('should work with all attributes specified in the options', done => {
+      let el = template.querySelector('#test-other-attr');
+      expect(el.innerHTML.trim()).toBe('Description');
+      sut.setLocale('de').then(() => {
+        expect(el.innerHTML.trim()).toBe('Beschreibung');
+        done();
+      });
     });
-  });
 
-  it('should set the textContent when using the [text] attribute', done => {
-    let el = template.querySelector('#test-text');
-    expect(el.innerHTML.trim()).toBe('Description');
-    sut.setLocale('de').then(() => {
-      expect(el.innerHTML.trim()).toBe('Beschreibung');
-      done();
+    it('should set the textContent when using the [text] attribute', done => {
+      let el = template.querySelector('#test-text');
+      expect(el.innerHTML.trim()).toBe('Description');
+      sut.setLocale('de').then(() => {
+        expect(el.innerHTML.trim()).toBe('Beschreibung');
+        done();
+      });
     });
-  });
 
-  it('should escape html tags by default or when using [text]', done => {
-    let el = template.querySelector('#test-text-with-tags');
-    expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>');
-    sut.setLocale('de').then(() => {
-      expect(el.innerHTML.trim()).toBe('Beschreibung &lt;b&gt;mit Fettdruck&lt;/b&gt;');
-      done();
+    it('should escape html tags by default or when using [text]', done => {
+      let el = template.querySelector('#test-text-with-tags');
+      expect(el.innerHTML.trim()).toBe('Description &lt;b&gt;with some bold&lt;/b&gt;');
+      sut.setLocale('de').then(() => {
+        expect(el.innerHTML.trim()).toBe('Beschreibung &lt;b&gt;mit Fettdruck&lt;/b&gt;');
+        done();
+      });
     });
-  });
 
-  it('should allow tags when using the [html] attribute', done => {
-    let el = template.querySelector('#test-html');
-    expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>');
-    sut.setLocale('de').then(() => {
-      expect(el.innerHTML.trim()).toBe('Beschreibung <b>mit Fettdruck</b>');
-      done();
+    it('should allow tags when using the [html] attribute', done => {
+      let el = template.querySelector('#test-html');
+      expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>');
+      sut.setLocale('de').then(() => {
+        expect(el.innerHTML.trim()).toBe('Beschreibung <b>mit Fettdruck</b>');
+        done();
+      });
     });
   });
 
   it('should prepend the translation when using the [prepend] attribute, and it allows html', done => {
-    let el = template.querySelector('#test-prepend');
-    expect(el.innerHTML.trim()).toBe('content');
-    sut.setLocale('de').then(() => {
-      expect(el.innerHTML.trim()).toBe('Beschreibung <b>mit Fettdruck</b>content');
-      return sut.setLocale('en');
-    }).then(() => {
-      expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>content');
-      done();
-    });
+      let el = template.querySelector('#test-prepend');
+      expect(el.innerHTML.trim()).toBe('content');
+      sut.setLocale('de').then(() => {
+        expect(el.innerHTML.trim()).toBe('Beschreibung <b>mit Fettdruck</b>content');
+        return sut.setLocale('en');
+      }).then(() => {
+        expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>content');
+        done();
+      });
   });
 
   it('should append the translation when using the [append] attribute, and it allows html', done => {
@@ -173,7 +181,7 @@ describe('testing i18n translation update', () => {
 
   it('should set multiple keys when separated with a semicolon', done => {
     let el = template.querySelector('#test-multiple');
-    expect(el.innerHTML.trim()).toBe('Description <b>with some bold</b>');
+    expect(el.innerHTML.trim()).toBe('Wrong Description <b>with some bold</b>');
     expect(el.className).toBe('');
     sut.setLocale('de').then(() => {
       expect(el.innerHTML.trim()).toBe('Beschreibung <b>mit Fettdruck</b>');

--- a/test/unit/i18n.update-translations.spec.js
+++ b/test/unit/i18n.update-translations.spec.js
@@ -23,6 +23,7 @@ describe('testing i18n translation update', () => {
           'description2': 'Description <b>with some bold</b>',
           'nested_referencing': 'The $t(title) is the header',
           'description-class': 'red',
+          'params': 'My name is {{name}}',
           'testimage': 'testimage-english.jpg'
         }
       },
@@ -33,6 +34,7 @@ describe('testing i18n translation update', () => {
           'description2': 'Beschreibung <b>mit Fettdruck</b>',
           'nested_referencing': 'Der $t(title) ist der Kopf',
           'description-class': 'blue',
+          'params': 'Meine Name ist {{name}}',
           'testimage': 'testimage-german.jpg'
         }
       }
@@ -114,6 +116,16 @@ describe('testing i18n translation update', () => {
       expect(template.querySelector('#test-nested').innerHTML.trim()).toBe('The Title is the header');
       sut.setLocale('de').then(() => {
         expect(template.querySelector('#test-nested').innerHTML.trim()).toBe('Der Titel ist der Kopf');
+        done();
+      });
+    });
+
+    it('should translate paramaters', done => {
+      sut.updateValue(template.querySelector('#test-params'), 'params', {name: 'Aurelia'}).then(() => {
+        expect(template.querySelector('#test-params').innerHTML.trim()).toBe('My name is Aurelia');
+        return sut.setLocale('de');
+      }).then(() => {
+        expect(template.querySelector('#test-params').innerHTML.trim()).toBe('Meine Name ist Aurelia');
         done();
       });
     });


### PR DESCRIPTION
When the locale is change I18N#updateTranslations is triggered. This
function will call I18N#updateValue to update the translation of the
nodes. However, it will never pass the params parameters which is used
to remplate parameters in translation string by their value.

With this patch, when the value of the parameters is specified in
I18N#updateValue (for instance when it is updated in TCustomAttribute),
it is save in the I18N#params object under the translation name. The
value is then retrieved in I18N#updateValue if no parameters value is
supplied.

Note: I am not sure if my tests are good.

Close #116 