### PR TITLE
fix(nf-vc): changed signature of NfValueConverter

### DIFF
--- a/src/nf.js
+++ b/src/nf.js
@@ -6,8 +6,21 @@ export class NfValueConverter {
     this.service = i18n;
   }
 
-  toView(value, formatOptions, locale, numberFormat) {
-    let nf = numberFormat || this.service.nf(formatOptions, locale || this.service.getLocale());
+  toView(value, nfOrOptions, locale, nf) {
+    if (value === null
+      || typeof value === 'undefined'
+      || (typeof value === 'string' && value.trim() === '')
+      ) {
+      return value;
+    }
+
+    if (nfOrOptions && (typeof nfOrOptions.format === 'function')) {
+      return nfOrOptions.format(value);
+    } else if (nf) {
+      console.warn('This ValueConverter signature is depcrecated and will be removed in future releases. Please use the signature [nfOrOptions, locale]'); // eslint-disable-line no-console
+    } else {
+      nf = this.service.nf(nfOrOptions, locale || this.service.getLocale());
+    }
 
     return nf.format(value);
   }


### PR DESCRIPTION
This update is proposed to bring it in line with the number formatter which addressed two issues (#100 & #101)

I'm not sure what the number formatter does with null or empty values but I think it makes sense to copy the behaviour from the date formatter in this case.