### PR TITLE
feat(i18n): add dependency injection

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,8 +1,11 @@
 /*eslint no-cond-assign: 0*/
 import i18next from 'i18next';
 import {DOM} from 'aurelia-pal';
+import {EventAggregator} from 'aurelia-event-aggregator';
+import {BindingSignaler} from 'aurelia-templating-resources';
 
 export class I18N {
+  static inject = [EventAggregator, BindingSignaler];
 
   globalVars = {};
   params = {};


### PR DESCRIPTION
This will let `I18N` to be injected with required dependencies even if the plugin `configure` function is not called. This would be useful to configure the library by other means than inside bootstrapping, for example as an optional dependency in submodules.