### PR TITLE
Using non-default defaultNS and adding namespaces dynamically

### DIFF
--- a/src/relativeTime.js
+++ b/src/relativeTime.js
@@ -47,7 +47,7 @@ export class RelativeTime {
       }
     }
 
-    this.service.i18next.addResources(key, 'translation', translation);
+    this.service.i18next.addResources(key, options.defaultNS, translation);
   }
 
   getRelativeTime(time) {

--- a/test/unit/relative.time.spec.js
+++ b/test/unit/relative.time.spec.js
@@ -16,7 +16,7 @@ describe('testing relative time support', () => {
     i18n.setup({
       lng: 'en',
       fallbackLng: 'en',
-      defaultNS: 'translation',
+      defaultNS: 'custom_default',
       debug: false
     }).then(() => done());
   });


### PR DESCRIPTION
When using a non-default namespace, and you call the addNamespaces function it tries to load the specified namespace and also the 'translations' namespace.

This is due to the relativetime module being hard coded to the 'translations' namespace.