### PR TITLE
fix(attribute): TAttribute related fixes

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -150,16 +150,6 @@ export class I18N {
   }
 
   updateValue(node, value, params) {
-    if (params) {
-      this.params[value] = params;
-    } else if (this.params[value]) {
-      params = this.params[value];
-    }
-
-    return this.i18nextDefered.promise.then(() => this._updateValue(node, value, params));
-  }
-
-  _updateValue(node, value, params) {
     if (value === null || value === undefined) {
       return;
     }

--- a/src/t.js
+++ b/src/t.js
@@ -54,7 +54,7 @@ export class TCustomAttribute {
 
     let p = this.params !== null ? this.params.value : undefined;
     this.subscription = this.ea.subscribe('i18n:locale:changed', () => {
-      this.service.updateValue(this.element, this.value, p);
+      this.service.updateValue(this.element, this.value, this.params !== null ? this.params.value : undefined);
     });
 
     this.service.updateValue(this.element, this.value, p);

--- a/test/unit/i18n.spec.js
+++ b/test/unit/i18n.spec.js
@@ -51,7 +51,7 @@ describe('testing i18n translations', () => {
   it('should translate a simple key without options', () => {
     expect(sut.tr('friend', { count: 0 })).toEqual('A friend');
   });
-  
+
   it('should replace a not provided variable with an empty string', () => {
     expect(sut.tr('novar')).toEqual(' should be replaced with an empty string');
   });

--- a/test/unit/i18n.update-translations.spec.js
+++ b/test/unit/i18n.update-translations.spec.js
@@ -89,8 +89,11 @@ describe('testing i18n translation update', () => {
       System.import('fixture:template.html!text').then((result) => {
         template = document.createElement('div');
         template.innerHTML = result;
-        if (template.firstChild instanceof HTMLTemplateElement)
+
+        if (template.firstChild instanceof HTMLTemplateElement) {
           template.innerHTML = template.firstChild.innerHTML;
+        }
+
         document.body.appendChild(template);
         done();
       });
@@ -116,16 +119,6 @@ describe('testing i18n translation update', () => {
       expect(template.querySelector('#test-nested').innerHTML.trim()).toBe('The Title is the header');
       sut.setLocale('de').then(() => {
         expect(template.querySelector('#test-nested').innerHTML.trim()).toBe('Der Titel ist der Kopf');
-        done();
-      });
-    });
-
-    it('should translate paramaters', done => {
-      sut.updateValue(template.querySelector('#test-params'), 'params', {name: 'Aurelia'}).then(() => {
-        expect(template.querySelector('#test-params').innerHTML.trim()).toBe('My name is Aurelia');
-        return sut.setLocale('de');
-      }).then(() => {
-        expect(template.querySelector('#test-params').innerHTML.trim()).toBe('Meine Name ist Aurelia');
         done();
       });
     });


### PR DESCRIPTION
params are reissued properly on locale change. Removal of unnecessary
Promise wrapping of updateValue.

Fixes issue
https://github.com/aurelia/i18n/issues/156
https://github.com/aurelia/i18n/issues/147
https://github.com/aurelia/i18n/issues/143
https://github.com/aurelia/i18n/issues/116