### PR TITLE
Fix i18next-xhr-backend.d.ts array type error

### DIFF
--- a/doc/i18next-xhr-backend.d.ts
+++ b/doc/i18next-xhr-backend.d.ts
@@ -19,7 +19,7 @@ declare module 'i18next-xhr-backend' {
         };
         constructor(services: Services, options?: {});
         init(services: Services, options?: {}): void;
-        readMulti(languages: Array, namespaces: Array, callback: () => void): void;
+        readMulti(languages: Array<any>, namespaces: Array<any>, callback: () => void): void;
         read(language: {}, namespace: {}, callback: () => void): void;
         loadUrl(url: string, callback: () => void): void;
         create(languages: any[], namespace: string, key: string, fallbackValue: string): void;


### PR DESCRIPTION
Currently, if you try to use the `i18next-xhr-backend.d.ts` using TypeScript 2.0, you get the following error:

<pre>
Error: typings\globals\i18next-xhr-backend\index.d.ts(24,30): error TS2314: Generic type 'Array<T>' requires 1 type
 argument(s).
</pre>

The solution is to specify an type argument.