### PR TITLE
doc(using-aurelia-cli): add gulp.watch instructions

### DIFF
--- a/doc/article/en-US/i18n-with-aurelia.md
+++ b/doc/article/en-US/i18n-with-aurelia.md
@@ -945,10 +945,26 @@ With that in place, edit your `aurelia_project/aurelia.json` file and add the ta
       "id": "none",
       "displayName": "None",
       "fileExtension": ".json",
-      "source": "locales\\**\\*.json"
+      "source": "src/locales/**/*.json"
     },
     ...
 ```
+
+Also, edit your `aurelia_project/tasks/run.js` (or .ts if you're using Typescript) file and add a new gulp.watch task to the `watch` function:
+
+<code-listing heading="Add a locales watch task the watch function">
+  <source-code lang="ES 2015">
+  
+    let watch = function() {
+      gulp.watch(project.transpiler.source, refresh).on('change', onChange);
+      gulp.watch(project.markupProcessor.source, refresh).on('change', onChange);
+      gulp.watch(project.cssProcessor.source, refresh).on('change', onChange);
+      gulp.watch(project.localesProcessor.source, refresh).on('change', onChange); //<-- add this line
+    };
+  </source-code>
+</code-listing>
+
+By doing this, if you're running your project with the --watch flag, your bundles will be rebuilt whenever your change something in your translation files. In the same way that happens with your .html, .js and .css files.
 
 Last but not least search for the build/bundles/source section for the app-bundle and update the configuration to include json files.
 


### PR DESCRIPTION
The current docs don't show how to add a `gulp.watch` task to the translation files. Without this task, even if the `--watch` flag was provided, the user has to manually run `au run/build` whenever he changes the translation file.

In addition, CLI is using [posix](https://nodejs.org/api/path.html#path_path_posix) internally. So, paths with `\\something\\` aren't necessary anymore. (I haven't tested on Windows though)

The source property was changed from : `"locales/**/*.json"` to `"src/locales/**/*.json"` because `gulp.watch` needs the `src` part to work. The bundle works with or without it though.

Please, tell me if something is not right then I will edit the PR.

Thanks!