### PR TITLE
Fix no default export error for i18next

### DIFF
--- a/dist/aurelia-i18n.d.ts
+++ b/dist/aurelia-i18n.d.ts
@@ -1,4 +1,4 @@
-import i18next from 'i18next';
+import * as i18next from 'i18next';
 import * as LogManager from 'aurelia-logging';
 import {
   resolver


### PR DESCRIPTION
During a build I get this:

```
<my folder>/node_modules/aurelia-i18n/dist/aurelia-i18n.d.ts(1,8): error TS1192: Module ''i18next'' has no default export.
[15:38:17] gulp-notify: [Error running Gulp] Error: <my folder>/node_modules/aurelia-i18n/dist/aurelia-i18n.d.ts(1,8): error TS1192: Module ''i18next'' has no default export.
[15:38:17] TypeScript: 1 semantic error
[15:38:17] TypeScript: emit succeeded (with errors)
```

This fixes that error.