### PR TITLE
Fix error TS1192: 'i18next' has no default export.

### DIFF
--- a/dist/aurelia-i18n.d.ts
+++ b/dist/aurelia-i18n.d.ts
@@ -1,4 +1,4 @@
-import i18next from 'i18next';
+import * as i18next from 'i18next';
 import * as LogManager from 'aurelia-logging';
 import {
   resolver


### PR DESCRIPTION
Complete backtrace
node_modules/aurelia-i18n/dist/aurelia-i18n.d.ts(1,8): error TS1192: Module ''i18next'' has no default export.
[11:40:53] gulp-notify: [Error running Gulp] Error: /var/www/brandspot-ng/ui/node_modules/aurelia-i18n/dist/aurelia-i18n.d.ts(1,8): error TS1192: Module ''i18next'' has no default export.