### PR TITLE
fix(uf()): remove all thousand seperators

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -76,8 +76,8 @@ export class I18N {
     let thousandSeparator = comparer[1];
     let decimalSeparator  = comparer[5];
 
-    // remove thousand seperator
-    let result = number.replace(thousandSeparator, '')
+    // remove all thousand seperators
+    let result = number.replace(new RegExp(thousandSeparator, 'g'), '')
       // remove non-numeric signs except -> , .
       .replace(/[^\d.,-]/g, '')
       // replace original decimalSeparator with english one

--- a/test/unit/numberformat.spec.js
+++ b/test/unit/numberformat.spec.js
@@ -73,17 +73,17 @@ describe('numberformat tests', () => {
     });
 
     it('should keep the decimal separator', () => {
-      let sample = '1,234.56';
+      let sample = '1,234,567.89';
       let result = sut.uf(sample);
 
-      expect(result).toBe(1234.56);
+      expect(result).toBe(1234567.89);
     });
 
     it('should respect provided locale', () => {
-      let sample = '1.234,56';
+      let sample = '1.234.567,89';
       let result = sut.uf(sample, 'de');
 
-      expect(result).toBe(1234.56);
+      expect(result).toBe(1234567.89);
     });
 
     it('should remove currency symbols', () => {


### PR DESCRIPTION
Undocumented uf() should remove all commas when it parses a string such as "1,234,567".

Currently it removes only the first ',' and causes an error.
