### PR TITLE
fix(uf): RegExp should escape '.'

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -77,7 +77,7 @@ export class I18N {
     let decimalSeparator  = comparer[5];
 
     // remove all thousand seperators
-    let result = number.replace(new RegExp(thousandSeparator, 'g'), '')
+    let result = number.replace(new RegExp('\\' + thousandSeparator, 'g'), '')
       // remove non-numeric signs except -> , .
       .replace(/[^\d.,-]/g, '')
       // replace original decimalSeparator with english one


### PR DESCRIPTION
To remove '.' in '3.333,3', the '.' should be escaped as '\.' in RegExp. Sorry.