### PR TITLE
Resolves #236: Typings requires allowSyntheticDefaultImports = true f…

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -16,6 +16,7 @@ var gulpIgnore = require('gulp-ignore');
 var merge = require('merge2');
 var jsName = paths.packageName + '.js';
 var compileToModules = ['es2015', 'commonjs', 'amd', 'system', 'native-modules'];
+var replace = require("gulp-replace");
 
 function cleanGeneratedCode() {
   return through2.obj(function(file, enc, callback) {
@@ -64,6 +65,7 @@ gulp.task('build-index', function() {
 
 gulp.task('build-es2015-temp', function () {
     return gulp.src(paths.output + jsName)
+      .pipe(replace('import i18next from', 'import * as i18next from')) // Replace babel cjs import syntax with TS cjs import syntax
       .pipe(to5(assign({}, compilerOptions.commonjs())))
       .pipe(gulp.dest(paths.output + 'temp'));
 });

--- a/dist/aurelia-i18n.d.ts
+++ b/dist/aurelia-i18n.d.ts
@@ -1,5 +1,5 @@
 import * as LogManager from 'aurelia-logging';
-import i18next from 'i18next';
+import * as i18next from 'i18next';
 import {
   resolver
 } from 'aurelia-dependency-injection';
@@ -85,8 +85,6 @@ export declare class Backend {
   readMulti(languages?: any, namespaces?: any, callback?: any): any;
   read(language?: any, namespace?: any, callback?: any): any;
   loadUrl(url?: any, callback?: any): any;
-  
-  /* no retry */
   create(languages?: any, namespace?: any, key?: any, fallbackValue?: any): any;
 }
 export declare class BaseI18N {

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "gulp-ignore": "^2.0.1",
     "gulp-insert": "^0.5.0",
     "gulp-rename": "^1.2.2",
+    "gulp-replace": "^0.6.1",
     "gulp-typedoc": "^2.0.0",
     "gulp-typedoc-extractor": "0.0.8",
     "gulp-typescript": "^2.13.6",

--- a/src/customTypings/i18next.d.ts
+++ b/src/customTypings/i18next.d.ts
@@ -121,5 +121,5 @@ declare namespace I18next {
 declare module 'i18next' {
     var i18next:I18next.I18n;
 
-    export default i18next;
+    export = i18next;
 }


### PR DESCRIPTION
I forked the repo and then I first tried to make my singe line change to ./src/i18n.js as described earlier (please refer issue #236).

I then built the project and saw that the ./dist/aurelia-18n.d.ts was generated the way I wanted it to, but when running the tests afterwards, most of them were broken.

Even though I am not very experienced with Babel, when I debugged the tests, I discovered how the Babel transpiler injects a method "_interopRequireWildcard" to simulate default exports for CommonJS modules.

So to my current reenlightened knowledge, **_Babel_** expects you to use the syntax...
```javascript
import theModule from "./the-module.js";
```
...when importing **_CommonJS_** modules, whileas **_TypeScript_** by default expect you to use the syntax...
```typescript
import * as theModule from "./the-module.js";
```
...for CommonJS modules unless the _allowSyntheticDefaultExports_ compiler option is switched on (default is off). When this is switched on, _both_ import syntaxes are accepted by TypeScript.

The ideal solution for aurelia-i18n to accommodate TypeScript projects is therefore that the source file ./src/i18n.js continue to use the current syntax required by your Babel build/transpilation, but to ensure that the .d.ts file uses the wildcard import syntax expected by TypeScript projects using aurelia-i18n.

I have added a simple search-replace fix to your gulp build script that does exactly as described; please review it. You may know the build script better than me and you may know a better way than my search-replace technique to do accomplish the same, but my change anyway does exactly what is needed.

PS! This change will not be a breaking change for projects using the .d.ts file.

I hope the pull request will be accepted. It is as earlier mentioned unreasonable that the aurelia-i18n typings file imposes certain TypeScript compiler options to projects using the plugin. The allowSyntheticDefaultImports compiler option is lightly to be unwanted for the rest of the project's code base.