### PR TITLE
fix(i18n): stop forcing lng option

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,6 +21,7 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
+      'node_modules/babel-polyfill/browser.js',
       {pattern: 'test/unit/fixtures/**/*.html', included: false},
       // dont pre-load just serve if requested
       {pattern: 'test/unit/fixtures/**/*.jpg', watched: false, included: false, served: true}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   "bugs": {
     "url": "https://github.com/aurelia/i18n/issues"
   },
-  "scripts": {},
+  "scripts": {
+    "precommit": "gulp lint",
+    "test": "karma start"
+  },
   "license": "MIT",
   "author": "Rob Eisenberg <rob@bluespire.com> (http://robeisenberg.com/)",
   "main": "dist/commonjs/aurelia-i18n.js",
@@ -90,6 +93,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.11.5",
     "babel-plugin-transform-es2015-modules-systemjs": "^6.11.6",
     "babel-plugin-transform-flow-strip-types": "^6.8.0",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-es2015-loose": "^7.0.0",
     "babel-preset-es2015-loose-native-modules": "^1.0.0",

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -35,9 +35,6 @@ export class I18N {
       debug: false
     };
 
-    if (options && !options.lng) {
-      throw new Error('You need to provide the lng option');
-    }
 
     i18next.init(options || defaultOptions, (err, t) => {
       //make sure attributes is an array in case a string was provided

--- a/src/relativeTime.js
+++ b/src/relativeTime.js
@@ -1,6 +1,6 @@
-import {I18N} from './i18n';
-import {translations} from  './defaultTranslations/relative.time';
-import {EventAggregator} from 'aurelia-event-aggregator';
+import { I18N } from './i18n';
+import { translations } from './defaultTranslations/relative.time';
+import { EventAggregator } from 'aurelia-event-aggregator';
 
 export class RelativeTime {
   static inject() { return [I18N, EventAggregator]; }
@@ -18,8 +18,17 @@ export class RelativeTime {
 
   setup(locales) {
     let trans = translations.default || translations;
-    let key = locales && locales.newValue ? locales.newValue : this.service.getLocale();
     let fallbackLng = this.service.i18next.fallbackLng;
+
+    let alternateFb = fallbackLng || this.service.i18next.options.fallbackLng;
+    if (Array.isArray(alternateFb) && alternateFb.length > 0) {
+      alternateFb = alternateFb[0];
+    }
+
+    let key = ((locales && locales.newValue)
+      ? locales.newValue
+      : this.service.getLocale()) || alternateFb;
+
     let index = 0;
 
     if ((index = key.indexOf('-')) >= 0) { // eslint-disable-line no-cond-assign


### PR DESCRIPTION
stops forcing the lng option in favor of relativetime and uses the fallbackLng instead

Related issue https://github.com/aurelia/i18n/issues/254