### PR TITLE
doc(i18n-with-aurelia): remove unnecessary brace and fix indentation

### DIFF
--- a/doc/article/en-US/i18n-with-aurelia.md
+++ b/doc/article/en-US/i18n-with-aurelia.md
@@ -215,28 +215,27 @@ be slight differences. The following listings show the configuration for first t
     // otherwise add "allowSyntheticDefaultImports": true, to your tsconfig
 
     export function configure(aurelia) {
-        aurelia.use
-          .standardConfiguration()
-          .developmentLogging()
-          .plugin('aurelia-i18n', (instance) => {
-            let aliases = ['t', 'i18n'];
-            // add aliases for 't' attribute
-            TCustomAttribute.configureAliases(aliases);
+      aurelia.use
+        .standardConfiguration()
+        .developmentLogging()
+        .plugin('aurelia-i18n', (instance) => {
+          let aliases = ['t', 'i18n'];
+          // add aliases for 't' attribute
+          TCustomAttribute.configureAliases(aliases);
 
-            // register backend plugin
-            instance.i18next.use(Backend);
+          // register backend plugin
+          instance.i18next.use(Backend);
 
-            // adapt options to your needs (see http://i18next.com/docs/options/)
-            // make sure to return the promise of the setup method, in order to guarantee proper loading
-            return instance.setup({
-              backend: {                                  // <-- configure backend settings
-                loadPath: './locales/{{lng}}/{{ns}}.json', // <-- XHR settings for where to get the files from
-              },
-              attributes: aliases,
-              lng : 'de',
-              fallbackLng : 'en',
-              debug : false
-            });
+          // adapt options to your needs (see http://i18next.com/docs/options/)
+          // make sure to return the promise of the setup method, in order to guarantee proper loading
+          return instance.setup({
+            backend: {                                  // <-- configure backend settings
+              loadPath: './locales/{{lng}}/{{ns}}.json', // <-- XHR settings for where to get the files from
+            },
+            attributes: aliases,
+            lng : 'de',
+            fallbackLng : 'en',
+            debug : false
           });
         });
 


### PR DESCRIPTION
There was an extra brace `});` at the bottom. It probably wasn't noticed because of the extra indentation.