### PR TITLE
Updated dependencies for aurelia-binding (removed 1.x dependency)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       "dist": "dist/amd"
     },
     "dependencies": {
-      "aurelia-binding": "^1.0.0 || ^2.0.0",
+      "aurelia-binding": "^2.0.0",
       "aurelia-dependency-injection": "^1.0.0",
       "aurelia-event-aggregator": "^1.0.0",
       "aurelia-loader": "^1.0.0",
@@ -57,7 +57,7 @@
     }
   },
   "dependencies": {
-    "aurelia-binding": "^1.0.0 || ^2.0.0",
+    "aurelia-binding": "^2.0.0",
     "aurelia-dependency-injection": "^1.0.0",
     "aurelia-event-aggregator": "^1.0.0",
     "aurelia-loader": "^1.0.0",


### PR DESCRIPTION
To be able to install via JSPM (which doesn't support comparator sets for versioning)