### PR TITLE
Re-add typings.json

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -1,0 +1,4 @@
+{
+  "name": "aurelia-i18n",
+  "main": "dist/aurelia-i18n.d.ts"
+}

--- a/typings.json
+++ b/typings.json
@@ -1,4 +1,4 @@
 {
   "name": "aurelia-i18n",
-  "main": "dist/aurelia-i18n.d.ts"
+  "main": "dist/typings/aurelia-i18n.d.ts"
 }


### PR DESCRIPTION
npm typings install step was broken because this is missing

Started get build failures stating 
https://raw.githubusercontent.com/aurelia/i18n/master/typings.json responded with 404, expected it to equal 200