### PR TITLE
refactor(build): add umd build target, cdn fields

### DIFF
--- a/build/build.ts
+++ b/build/build.ts
@@ -31,7 +31,25 @@ const configs: Record<IBuildTargetFormat, { input: string; outputs: rollup.Outpu
   es2015: {
     input: ENTRY_PATH,
     outputs: [
-      { file: `dist/es2015/${DIST_FILE_NAME}`, format: 'esm' }
+      { file: `dist/es2015/${DIST_FILE_NAME}`, format: 'esm' },
+      {
+        file: `dist/umd/${DIST_FILE_NAME}`,
+        format: 'umd',
+        name: 'au.i18n',
+        globals: {
+          'aurelia-framework': 'au',
+          'aurelia-binding': 'au',
+          'aurelia-metadata': 'au',
+          'aurelia-templating': 'au',
+          'aurelia-loader': 'au',
+          'aurelia-event-aggregator': 'au',
+          'aurelia-pal': 'au',
+          'aurelia-templating-resources': 'au',
+          'aurelia-logging': 'au.LogManager',
+          'aurelia-dependency-injection': 'au',
+          'i18next': 'i18next'
+        }
+      }
     ]
   },
   es5: {

--- a/package.json
+++ b/package.json
@@ -87,6 +87,9 @@
     "Rob Eisenberg <rob@bluespire.com> (http://robeisenberg.com/)"
   ],
   "main": "dist/commonjs/aurelia-i18n.js",
+  "module": "dist/es2015/aurelia-i18n.js",
+  "browser": "dist/umd/aurelia-i18n.js",
+  "unpkg": "dist/umd/aurelia-i18n.js",
   "typings": "dist/aurelia-i18n.d.ts",
   "repository": {
     "type": "git",


### PR DESCRIPTION
@zewa666 From typings file, I assume namespace of i18next is `i18next`, please change if needed in `build.ts`

cc @EisenbergEffect 