### PR TITLE
fix(i18n): Fix typings issue for i18next import

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,4 +1,4 @@
-import i18next from "i18next";
+import * as i18next from "i18next";
 import {
   DOM,
   PLATFORM


### PR DESCRIPTION
The current import syntax produces a .d.ts file that requires the consuming app to compile with `allowSyntheticDefaultImports: true`.