### PR TITLE
chore(build) use "import * as i18next" in generated .d.ts file

### DIFF
--- a/build/build.ts
+++ b/build/build.ts
@@ -189,7 +189,7 @@ async function generateDts(): Promise<void> {
 }
 
 async function fixI18nDefaultImport(typeDefFileName: string) {
-  const importDeclaration = `import i18next from 'i18next';\n`;
+  const importDeclaration = `import * as i18next from 'i18next';\n`;
   const data = fs.readFileSync(typeDefFileName, 'utf-8');
   const fd = fs.openSync(typeDefFileName, 'w+');
   fs.writeSync(fd, Buffer.from(importDeclaration, 'utf8'), 0, importDeclaration.length, 0);


### PR DESCRIPTION
Use the `import * as i18next from 'i18next'` syntax in the generated .d.ts file. This PR replaces https://github.com/aurelia/i18n/pull/297.
