### PR TITLE
Removed i18next default import typings fix

### DIFF
--- a/build/build.ts
+++ b/build/build.ts
@@ -58,7 +58,7 @@ const configs: Record<IBuildTargetFormat, { input: string; outputs: rollup.Outpu
       { file: `dist/commonjs/${DIST_FILE_NAME}`, format: 'cjs' },
       { file: `dist/amd/${DIST_FILE_NAME}`, format: 'amd', amd: { id: LIB_NAME } },
       { file: `dist/native-modules/${DIST_FILE_NAME}`, format: 'esm' },
-      { 
+      {
         file: `dist/umd/${DIST_FILE_NAME}`,
         format: 'umd',
         name: 'au.i18n',
@@ -168,7 +168,7 @@ if (args.dev) {
 
 async function generateDts(): Promise<void> {
   console.log('\n==============\nGenerating dts bundle...\n==============');
-  return new Promise<void>((resolve, reject) => {
+  return new Promise<void>(resolve => {
     ChildProcess.exec(`npm run build:dts`, (err, stdout, stderr) => {
       if (err || stderr) {
         console.log('Generating dts error:');
@@ -177,24 +177,9 @@ async function generateDts(): Promise<void> {
         console.log('Generated dts bundle successfully');
         console.log(stdout);
       }
-      try {
-        fixI18nDefaultImport(path.resolve(DIST_DIR, TYPE_DIST_FILE_NAME));
-      } catch (ex) {
-        console.log('Failure fixing default import.');
-        reject(ex);
-      }
       resolve();
     });
   });
-}
-
-async function fixI18nDefaultImport(typeDefFileName: string) {
-  const importDeclaration = `import i18next from 'i18next';`;
-  const data = fs.readFileSync(typeDefFileName, 'utf-8')
-    .replace("import { i18next } from 'i18next';", importDeclaration);
-  const fd = fs.openSync(typeDefFileName, 'w+');
-
-  fs.writeSync(fd, Buffer.from(data, 'utf8'));
 }
 
 function copyToTargetProject(targetFormats: string[], targetProject: string) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -182,12 +182,6 @@
       "integrity": "sha512-y5x0XD/WXDaGSyiTaTcKS4FurULJtSiYbGTeQd0m2LYZGBcZZ/7fM6t5H/DzeUF+kv8y6UfmF6yJABQsHcp9VQ==",
       "dev": true
     },
-    "@types/i18next": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/@types/i18next/-/i18next-8.4.5.tgz",
-      "integrity": "sha512-FUvAb4r6X2GWXc7j+jIIXcRcxCqSzMkWkkflcdl9Vhb1C9MrJqIqm8thtzqONEqGtWqoMMSv3piboImgIRwmVw==",
-      "dev": true
-    },
     "@types/intl": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@types/intl/-/intl-1.2.0.tgz",
@@ -3869,9 +3863,9 @@
       }
     },
     "i18next": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-14.0.1.tgz",
-      "integrity": "sha512-wsKfQuYsy4RdCaqqN71eDjWMhizhTfQSIBGttEA7vcboQrUfpQlCezrSzrtmoW9F9tmVyNs38iBgLYLMhRSeIQ=="
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-14.1.1.tgz",
+      "integrity": "sha512-HItn9RHLyrDqe6pw6qXMYHGPHNc3y1FZndJfBlD6k4sRS0FAlYLvqCDVIWFc1XultBgsv348TtvL/lleG6JgBg=="
     },
     "iconv-lite": {
       "version": "0.4.23",

--- a/package.json
+++ b/package.json
@@ -125,10 +125,9 @@
     "aurelia-pal": "^1.3.0",
     "aurelia-templating": "^1.8.2",
     "aurelia-templating-resources": "^1.7.1",
-    "i18next": "^14.0.1"
+    "i18next": "^14.1.1"
   },
   "devDependencies": {
-    "@types/i18next": "^8.4.5",
     "@types/intl": "^1.2.0",
     "@types/jest": "^21.1.10",
     "@types/node": "^8.10.26",


### PR DESCRIPTION
Fixes #324

* Removed @types/i18next devDependency (deprecated)
* Updated i18next dependency from 14.0.1 to 14.1.1 - now with typings includes.
* Removed the typings fix part of the build script - should no longer be needed when using the typings from the i18next package (default import statement in aurelia-18n typings is now correct since i18next typings has default export. No special tsconfig settings should be required anymore).