### PR TITLE
I18N.tr has wrong options overload type

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -122,7 +122,7 @@ export class I18N {
   }
 
   // tslint:disable-next-line: max-line-length
-  public tr<TResult extends string | object | Array<string | object> | undefined = string>(key: string | string[], options?: TOptions<object>) {
+  public tr<TResult extends string | object | Array<string | object> | undefined = string>(key: string | string[], options?: TOptions) {
     let fullOptions = this.globalVars;
 
     if (options !== undefined) {


### PR DESCRIPTION
fix aurelia#352. Without this we get errors with i18n.tr("key", {param: value}).